### PR TITLE
Q16 domaine 4 — les actes, les graphiques, les surfaces : le catalogue au complet (D511–D565)

### DIFF
--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2116,7 +2116,9 @@ charts:
    **l'icône au bord opposé** (*la collision avec le layout des
    sections D490 notée — les valeurs départagent, D458*) ; `drill:`
    (D242) ; **pas de comparaison dans le socle** (D245 —
-   l'évolution contre une période = un hook) ;
+   l'évolution contre une période = un hook) ; *(la note pour plus
+   tard — D541 : la tendance issue de l'historique de l'entité,
+   D411/D172 — le détail différé)* ;
 6. **Items** — aucun ;
 7. **Modes et déclinaisons** — **« mis en valeur avec un style
    différent de la feuille »** (D527) : le chiffre en exergue, jamais

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2570,12 +2570,13 @@ widgets:
    dans son agrégat (D101) ;
 4. **Contexte consommé** — l'enregistrement transitoire, l'origine de
    l'appel, l'utilisateur (D455) ; les droits (D196) ;
-5. **Propriétés** — `title:` (D449/D465) ; **`size:` obligatoire** —
-   « un wizard doit avoir une dimension », **surchargeable au nœud
-   incluant** quand il s'emboîte dans un formulaire (D548/D455, le
-   plus proche l'emporte D461 ; la pile D535, la grammaire D533) ;
-   **le fil d'Ariane en haut ou en bas** (D548 — *en proposition :*
-   `mode: top` (défaut) `| bottom`, les bords D525) ; `screen:`
+5. **Propriétés** — `title:` (D449/D465) ; **`size:` optionnel** — « sans
+   valeur, ça prend l'espace disponible ; en cas d'appel depuis un
+   menu, le wizard prend tout l'écran » (D549) ; surchargeable au
+   nœud incluant quand il s'emboîte dans un formulaire (D548/D455,
+   le plus proche l'emporte D461 ; la grammaire D533) ;
+   **`breadcrumb: none | top | bottom`** — le fil d'Ariane (D549,
+   défaut `top` — les étapes visibles D504 ; `none` le masque) ; `screen:`
    (D450/D532) ; **les étapes = des surfaces déclarées**
    (D231) ; **les transitions conditionnelles** — « si client
    étranger → étape TVA » (D231/D90) ; **la transaction finale**
@@ -2612,7 +2613,7 @@ widgets:
    l'interruption emporte le transitoire (D547 — le draft effacé) ;
 9. **Décisions fondatrices** — D90, D101, D196, D230–D233, D431,
    D438–D439, D449–D450, D455, D465, D504–D505, D507, D511, D525,
-   D532–D533, D535, D546–D548 ;
+   D532–D533, D535, D546–D549 ;
 10. **Exemple de configuration** —
 
 ```yaml

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2375,3 +2375,49 @@ forms:
       - field[customer]
       - field[lines]
 ```
+
+## `summary`
+
+1. **Nom et famille** — `summary`, une surface — `gui: summaries:
+   <nom>:` (*l'écriture en proposition*) ; la première déclarée = le
+   défaut (D438) — mais **« défaut : n'existe pas »** (D201) : sans
+   déclaration, l'entité n'offre aucun résumé ;
+2. **Rôle** — l'enregistrement en bref : **« petit par principe »**
+   (D201) — le visage déployé d'une référence (D215), la carte qui se
+   montre sans quitter le contexte ;
+3. **Types servis** — l'entité ; l'appel vient d'ailleurs : la
+   référence 1-1 (D186/D215 — le libellé, puis le résumé), le widget ;
+4. **Contexte consommé** — l'enregistrement, l'origine de l'appel,
+   l'utilisateur (D455) ; les droits (D196), la confidentialité ;
+5. **Propriétés** — **une config de formulaire restreinte** (D201) :
+   les champs **sélectionnés**, **lecture seule et/ou modification**
+   (le `mode` au nœud — D461) ; `title:` (D449/D465) ; `size:` — la
+   surimpression sur la pile, petite par principe (D535/D533) ;
+   `screen:` (D450/D532) ;
+6. **Items** — la restriction du formulaire : les sections seules
+   (D490) et les feuilles — **« pas d'onglets, sections possibles »**
+   (D201) ; le `pages` implicite réduit à l'unique page ;
+7. **Modes et déclinaisons** — l'appel depuis la référence (D215 — le
+   1-1 affiche le libellé, le résumé se déploie) ; la lecture seule
+   et/ou la modification mêlées (D201) ; le responsive au repli
+   (D203) ;
+8. **États et interactions** — les droits décident du modifiable ; la
+   fermeture rend à la surface précédente (la pile — D535) ;
+9. **Décisions fondatrices** — D186, D196, D201, D203, D215,
+   D437–D438, D449–D450, D455, D461, D465, D490, D532–D533, D535 ;
+10. **Exemple de configuration** —
+
+```yaml
+# crm/entities/customer.yml, bloc gui — le résumé du client
+summaries:
+  card:                            # sans déclaration : aucun résumé (D201)
+    title: "{name}"
+    size: 30%                      # petit par principe (D201), centré (D533)
+    page:
+      - field[name]
+      - field[phone]
+      - field[balance]: { mode: read-only }   # le mêlé lecture/modification (D201)
+
+# et depuis la commande : field[customer] affiche le title (D465) ;
+# le clic déploie ce résumé au-dessus de la pile (D215/D535)
+```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2102,7 +2102,10 @@ charts:
    `title:` (D493), `labels:` — le gabarit du format (D516,
    `{value}`) ; **`colors:` par seuils** — le chiffre qui change de
    couleur (la mécanique D467, la table d'entité D495 comprise) ;
-   `drill:` (D242) ; **pas de comparaison dans le socle** (D245 —
+   **`icons:` par seuils** — « associer éventuellement une icône :
+   cas d'un feu tricolore » (D526 — la mécanique D467 dupliquée ; la
+   collision avec la feuille `icons` notée, le contexte départage
+   D458 ; la liaison `icon:` à la table D495) ; `drill:` (D242) ; **pas de comparaison dans le socle** (D245 —
    l'évolution contre une période = un hook) ;
 6. **Items** — aucun ;
 7. **Modes et déclinaisons** — **le widget roi** (l'entité → le
@@ -2112,7 +2115,7 @@ charts:
 8. **États et interactions** — le clic : le drill-down (D242) ou les
    valeurs du calcul (D516) ; la confidentialité masque ;
 9. **Décisions fondatrices** — D158, D242–D243, D245, D247–D249,
-   D467, D495, D512, D515–D518 ;
+   D467, D495, D512, D515–D518, D526 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -2125,5 +2128,7 @@ charts:
     title: { fr: CA du mois }
     labels: { fr: "{value} € HT" }
     colors: { 0: red, 50000: orange, 100000: green }   # les seuils (D467)
+    icons:  { 0: red_light.svg, 50000: orange_light.svg, 100000: green_light.svg }
+                                 # le feu tricolore (D526)
     drill: invoiced              # le clic : la liste (D242)
 ```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -42,7 +42,8 @@ matérialisation ; l'analogie des web components est consignée (D455).
   `toggle` · `dropdown`/`radios`/`icons` · `picker.record` ·
   `picker.image` · `picker.file` · `picker.color` · `viewer` · `map` · `paragraph` · `picture` ·
   `thread` · `list` (l'éditeur du type liste) · `password` (la saisie
-  masquée, D463) · `color` (la pastille — D496) — **le composant par défaut d'un type porte le nom du
+  masquée, D463) · `color` (la pastille — D496) · `qrcode`/`barcode`
+  (les composants de sortie — D300/D542) — **le composant par défaut d'un type porte le nom du
   type** (D458) ;
 - **Les graphiques** : la famille pointée **`chart.line`** ·
   **`chart.bars`** · **`chart.pie`** · **`chart.combo`** ·
@@ -75,7 +76,7 @@ Quatre règles transversales l'allègent :
 | Type | Composant par défaut | Compatibles (`component:`) |
 |---|---|---|
 | `boolean` | `checkbox` (3 états — faux→vrai→nul) | `toggle` |
-| `text` | `text` (mono/multi-ligne déduit D361, `shortcut` D464) | R3 si `values:` |
+| `text` | `text` (mono/multi-ligne déduit D361, `shortcut` D464) | R3 si `values:` ; `qrcode`/`barcode` (la sortie — D300/D542) |
 | `integer` | `number` (masque D372) | `calculator` ; le stepper [-]/[+] (D269) ; R2 si borné ; R3 si `values:` |
 | `decimal` | `number` (décimales, storage D378) | `calculator` ; R2 si borné ; R3 si `values:` |
 | `duration` | `number` masqué (la virgule en centièmes — D380) | `calculator` **sur la base de deux `clock`** — le début, la fin, la différence (D499) |
@@ -113,7 +114,7 @@ Quatre règles transversales l'allègent :
 | le lien n-aire — `list of [a, b]` / `association with [a, b]` (D402) | la liste embarquée (les combinaisons en lignes) | `widget:` (D492) |
 | l'association dérivée — `association with <entité> if …` (D405) | la liste embarquée **en lecture** | `widget:`, `viewer` au visage |
 | la liste nommée (l'accès retour automatique du 1-N — D216/D394) | la liste embarquée | comme l'association |
-| `counter` | la valeur assemblée, lecture seule partout (D155/D297) | — |
+| `counter` | la valeur assemblée, lecture seule partout (D155/D297) | `qrcode`/`barcode` (l'étiquette — D252/D542) |
 | le champ calculé | le composant de son type de résultat (D298) | les compatibles de ce type |
 | le statut (`states:`) | déduit de la déclaration : la liste navigatrice ou la lecture + boutons (D427) | `dropdown` — la liste des valeurs **tenant compte du cycle de vie** : les états atteignables seuls (D500) |
 
@@ -2200,6 +2201,50 @@ charts:
     sort: -value                 # les plus gros CA d'abord (D528)
     filter: state = "invoiced"
     title: { fr: CA par commercial et par mois }
+```
+
+## `qrcode` / `barcode`
+
+1. **Nom et famille** — `qrcode` et `barcode`, deux feuilles
+   jumelles — **les composants de sortie** (D300, clôt Q56) ; une
+   fiche commune (D542 — le manque relevé par l'auteur) ;
+2. **Rôle** — **« ils rendent la valeur d'un champ »** (D300) — la
+   valeur encodée, lisible à la machine : l'étiquette, le document,
+   l'écran ;
+3. **Types servis** — les champs à valeur textuelle — le texte, le
+   compteur, l'`uuid`, la référence… : **la conversion en texte du
+   type** (D369) fait la valeur encodée ; en surcharge
+   (`component: qrcode`) ;
+4. **Contexte consommé** — le champ, sa valeur convertie (D369), les
+   droits ;
+5. **Propriétés** — le socle (D461) ; `size:` (D484/D533) ; **le
+   format du code-barres au crochet** (*en proposition :*
+   `barcode[ean13]`, `barcode[code128]` — le défaut `code128`) ;
+6. **Items** — aucun ;
+7. **Modes et déclinaisons** — **la sortie d'abord** : le PDF et
+   l'étiquette (D252 — l'impression directe du serveur, les
+   imprimantes de l'OS), l'écran en lecture ; **Excel = la valeur
+   source** (D300) ; jamais la saisie (*le scan reste hors D300 — la
+   question pour plus tard si besoin*) ;
+8. **États et interactions** — la lecture seule par nature ; masqué
+   par la confidentialité ;
+9. **Décisions fondatrices** — D252, D300, D369, D461, D484, D542 ;
+10. **Exemple de configuration** —
+
+```yaml
+# stock/entities/product.yml
+fields:
+  sku: counter[product]            # le compteur mutualisé (D410)
+
+gui:
+  templates:
+    label:                         # l'étiquette imprimée du serveur (D252)
+      page:
+        - field[sku]:
+            component: qrcode      # la valeur rendue en QR (D300)
+        - field[name]
+        - field[price]:
+            component: barcode[ean13]   # le format au crochet (proposition)
 ```
 
 # Les surfaces

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -1935,3 +1935,42 @@ charts:
     x: site
     y: [ sum(reserved), sum(available) ]
 ```
+
+## `chart.pie`
+
+1. **Nom et famille** — `chart.pie`, un graphique de la famille
+   pointée (D512) — les secteurs : « camembert/anneau » (D239) ;
+2. **Rôle** — la répartition d'un tout : chaque part son secteur ;
+3. **Types servis** — l'assise (D517–D518) ; `x:` = le découpage **par
+   valeurs** (les parts — D240), `y:` = l'agrégat qui mesure la part ;
+4. **Contexte consommé** — le socle des `chart.*` : la confidentialité
+   héritée surchargeable (D247), les droits ;
+5. **Propriétés** — **le socle commun** (D515–D518 : `on:`, `x:`,
+   `y:`, `filter:`, `drill:`, `colors:`, `labels:`, `title:`) ; **les
+   écarts propres** (*en proposition*) : **`mode: pie | donut`** — le
+   camembert (défaut) ou l'anneau (D239 ; le crochet en raccourci :
+   `chart.pie[donut]`, D478) ; **la variable `{percent}`** au gabarit
+   des labels (D516 — la part en pourcentage, à côté de `{value}`) ;
+   **le regroupement des petites parts en « autres »** — un seuil,
+   rien par défaut ;
+6. **Items** — aucun ;
+7. **Modes et déclinaisons** — réutilisable : le widget, le
+   formulaire, le tableau de bord (D243/D249) ; **template** :
+   l'image (D257) ; tactile : la part touchée montre sa valeur ;
+8. **États et interactions** — le drill-down au clic (D242) ; le clic
+   sur une part : les valeurs du calcul (D516) ; la confidentialité
+   masque ;
+9. **Décisions fondatrices** — D239–D243, D247–D249, D512,
+   D515–D518 ;
+10. **Exemple de configuration** —
+
+```yaml
+# sales/entities/order.yml, bloc gui
+charts:
+  revenue_by_category:
+    component: chart.pie[donut]     # ≡ mode: donut — l'anneau (D239/D478)
+    x: category                     # les parts (D240 — par valeurs)
+    y: sum(total)
+    labels: { fr: "{percent} %" }   # le gabarit — {percent} (proposition)
+    drill: by_category              # la liste au filtre imposé (D242)
+```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -253,7 +253,11 @@ gui:
    `component` ; **`shortcut:`** — le raccourci du texte long (D464) :
    `lines` (les lignes visibles), `icon` (l'icône du déploiement),
    `label` (le libellé par langue — « Voir plus ») ; absent, le moteur
-   applique son défaut traduit (thème E) ;
+   applique son défaut traduit (thème E) ; **`style:`** — « la fonte,
+   la taille et sa mise en forme » (D536) : le défaut au **style
+   global de l'application**, la surcharge à la cascade D461 (*en
+   proposition : `style: { font: Roboto, size: 14px, format: [bold,
+   italic] }` — le size intérieur = la police, D458 départage*) ;
 6. **Items** — aucun ;
 7. **Modes et déclinaisons** — modification : la saisie, guidée par le
    masque s'il existe (les lignes du masque font les lignes de la zone,

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2675,15 +2675,18 @@ wizards:
    `widget[order.monthly]`) ; les graphiques directs
    (`chart[<nom>]` — D243/D540) ; les `sections` et leurs layouts
    pour la disposition (D489–D491) ;
-7. **Modes et déclinaisons** — **le dashboard déclaré ≠ la page
-   d'accueil composée** : l'accueil reste à l'utilisateur (D204 — le
-   pool des widgets de ses modules) ; le tableau de bord est l'œuvre
-   du technicien, au module ; le responsive au repli (D203) ;
+7. **Modes et déclinaisons** — **le même objet, deux auteurs**
+   (D554) : **le technicien déclare le panel** (les dashboards du
+   module — le menu, l'accueil pointé) ; **l'utilisateur compose le
+   sien** — la page d'accueil = un dashboard personnel, pioché dans
+   le pool des widgets de ses modules, sous sa confidentialité
+   (D204/D247/D191) ; le responsive au repli (D203) ;
 8. **États et interactions** — **le drill-down** de chaque widget
    (D202/D242) ; la confidentialité masque widget par widget (D247) ;
    le rafraîchissement vit selon son mode (D249) ;
-9. **Décisions fondatrices** — D202–D204, D242–D243, D247–D249,
-   D434, D438–D439, D449–D450, D455, D461, D465, D532, D535, D540 ;
+9. **Décisions fondatrices** — D191, D202–D204, D242–D243,
+   D247–D249, D434, D438–D439, D449–D450, D455, D461, D465, D532,
+   D535, D540, D554 ;
 10. **Exemple de configuration** —
 
 ```yaml

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2043,3 +2043,44 @@ charts:
       - { zone: [2,1], title: { fr: À éviter },      color: red }
     labels: true                  # le visage au survol (D386)
 ```
+
+## `chart.combo`
+
+1. **Nom et famille** — `chart.combo`, un graphique de la famille
+   pointée (D512) — le combiné ;
+2. **Rôle** — deux mesures d'un regard : **« courbe + barres ou deux
+   courbes, 2 axes Y max, même temporalité/échantillon »** (D239) ;
+3. **Types servis** — l'assise (D517–D518) ; **un `x:` commun** (le
+   même découpage — la même temporalité par construction) ; **deux
+   séries `y:`, chacune son axe** (gauche/droite) ;
+4. **Contexte consommé** — le socle des `chart.*` (la confidentialité
+   D247, les droits) ;
+5. **Propriétés** — **le socle commun** (D515–D518, D521 —
+   `display:` compris) ; **les écarts propres** (*écritures en
+   proposition*) : `y:` en liste de séries —
+   `{ value:, as: line | bars, axis: left | right }` — la nature et
+   l'axe de chacune (défauts : la première à gauche, la seconde à
+   droite) ; **deux axes maximum** — « au-delà de 2 axes, illisible »
+   (D239) : la troisième série refusée à l'ingestion, le hook pour
+   aller au-delà ;
+6. **Items** — aucun ;
+7. **Modes et déclinaisons** — réutilisable (D243/D249) ; template :
+   l'image (D257) ; le tableau des valeurs — les deux séries en
+   colonnes (`display:` — D521) ;
+8. **États et interactions** — le drill-down au clic (D242) ; les
+   valeurs du calcul (D516) ; la confidentialité masque ;
+9. **Décisions fondatrices** — D239–D243, D247–D249, D512,
+   D515–D518, D521 ;
+10. **Exemple de configuration** —
+
+```yaml
+# sales/entities/order.yml, bloc gui
+charts:
+  activity:
+    component: chart.combo
+    x: date[month]               # le découpage commun (D239/D240)
+    y:
+      - { value: sum(total), as: bars, axis: left }    # le CA en barres
+      - { value: count(),    as: line, axis: right }   # le volume en courbe
+    labels: true
+```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -101,7 +101,8 @@ Quatre règles transversales l'allègent :
 | `phone` | `text` masqué (national par défaut D391) | — |
 | `geolocation` | `map` (la mini-carte, le pointage D294) | — |
 | `period` | les deux calendriers liés (début ≤ fin D391) | — |
-| `email`, `url`, `vat_number`, `siren`, `siret`, `iban`, `bic` | `text` (la validation intégrée D391) | — |
+| `url` | `text` — **le lien en lecture** : le clic ouvre dans un nouvel onglet, l'icône du lien externe en post-zone, l'ellipse en cellule (D563) | — |
+| `email`, `vat_number`, `siren`, `siret`, `iban`, `bic` | `text` (la validation intégrée D391) | — |
 | `communication` | `thread` (le fil D295/D393) | — |
 
 ### Les liens et les générés

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2298,3 +2298,74 @@ lists:
 
 # et le menu l'adresse (D439) : sales.order[pending]
 ```
+
+## `form`
+
+1. **Nom et famille** — `form`, une surface — `gui: forms: <nom>:` ;
+   **la première déclarée est le formulaire par défaut** (D438) ;
+   adressé par le menu (`[+form]` — D439), appelé par la liste
+   (`add:`/`update:`/`delete:` — D530), par une opération (la
+   relecture `validate:` — D431/D511) ;
+2. **Rôle** — l'enregistrement en face à face : **le formulaire
+   unique aux cinq usages** — la création, la modification, la
+   suppression, la consultation, la visualisation d'un historique
+   (D199) ;
+3. **Types servis** — l'entité — l'enregistrement dans son agrégat
+   (D101 : les compositions embarquées) ;
+4. **Contexte consommé** — **l'enregistrement, l'origine de l'appel,
+   l'utilisateur** (D455) ; les droits d'action (D196), la
+   confidentialité ; le `title` de l'entité (D465) ;
+5. **Propriétés** — **`title:`** — la zone de texte à gabarit,
+   déclinable par langue (D449/D453) : le `title` de l'entité
+   utilisable et surchargeable (D465) ; **`screen:`** — le support de
+   conception et l'autorisation (`[pc paysage]` défaut — D450/D532) ;
+   **`mode:`** — `read-only | updatable` (D453) ; **`history:`** —
+   `false` désactive l'onglet historique d'une entité historisée
+   (D453) ; **`dimension:`** — la surimpression à l'appel, défaut
+   100 % de l'écran (D454 — l'extension D484 ; la grammaire D533 :
+   une ou deux valeurs, % ou px) ;
+6. **Items** — **le `pages` implicite** (D509) : `header`, `page`(s),
+   `footer` — les clés à l'usuel, **la liste d'éléments au
+   multi-pages** (D510) ; dans les pages : les sections seules
+   (D490), l'organisateur `sections`, les `tabs`, les feuilles
+   (`field[<nom>]` — D460), les actes (`operation[<nom>]` — D511),
+   les documents (`template[<nom>]` — D483), les graphiques (D243) ;
+7. **Modes et déclinaisons** — **les cinq usages d'un seul
+   formulaire** (D199) : la création (les compteurs « *(attribué à la
+   validation)* » — D154/D199), la modification (la concurrence par
+   champ — D111), la suppression (la lecture seule + la
+   confirmation — D446), la consultation (`mode: read-only`),
+   l'historique (l'onglet — D453) ; **jamais de popup** (D196) ; la
+   relecture d'opération (D431 — lecture seule + confirmer/annuler) ;
+   le responsive au repli (D203) ;
+8. **États et interactions** — les droits déterminent l'usage offert
+   (D196) ; le refus de validation affiché au champ (D307) ; le
+   `title` en tête, vivant avec l'enregistrement ;
+9. **Décisions fondatrices** — D101, D111, D154, D196, D199, D203,
+   D307, D437–D438, D446, D449–D455, D460, D465, D483, D509–D511,
+   D530, D533 ;
+10. **Exemple de configuration** —
+
+```yaml
+# sales/entities/order.yml, bloc gui — le fil de la passe
+forms:
+  default:                          # la première déclarée = le défaut (D438)
+    title: "{number} — {customer}"  # le gabarit (D449) — le title de l'entité surchargé (D465)
+    screen: [pc paysage]            # le support (D450)
+    dimension: 75%                  # la surimpression centrée (D454/D533)
+    header:
+      items: [ field[number], field[state] ]
+    page:                           # le pages implicite (D509)
+      - section:
+          title: { fr: Client }
+          items: [ field[customer], field[date] ]
+      - field[lines]                # la composition — la liste embarquée (D486)
+      - field[discussion]           # le fil prend la place qu'on lui laisse (D485)
+    footer:
+      items: [ field[total], operation[invoice] ]   # l'acte au pied (D511)
+
+  quick_entry:                      # le formulaire d'add: de la liste (D530)
+    page:
+      - field[customer]
+      - field[lines]
+```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -1428,7 +1428,10 @@ page:                              # la section seule, directement (D490)
    langue du document (D369) et les chemins (`{customer.address.city}`
    — D71) ; **`if:`** — l'alinéa conditionnel (D90) ; **`style:`**
    (D536) et les titres à quatre niveaux (D250) ; le
-   **multi-alinéas** — la lettre d'un seul bloc ;
+   **multi-alinéas** — la lettre d'un seul bloc ; **la liste en puces
+   ou en indices** (D561) — la collection énumérée dans la lettre
+   (*en proposition :* `{overdue[bullets]}` / `{overdue[numbers]}` —
+   le `title` D465 par élément) ;
 6. **Items** — aucun ;
 7. **Modes et déclinaisons** — au formulaire : le paragraphe en
    place ; **template** : le texte du gabarit — les mentions légales
@@ -1437,7 +1440,7 @@ page:                              # la section seule, directement (D490)
 8. **États et interactions** — la visibilité par les droits ; rien
    d'autre — le texte ne se clique pas ;
 9. **Décisions fondatrices** — D71, D90, D250, D369, D440, D455,
-   D461, D465, D488, D536, D559–D560 ;
+   D461, D465, D488, D536, D559–D561 ;
 10. **Exemple de configuration** —
 
 ```yaml

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -1815,3 +1815,51 @@ gui:
     main:
       columns: [number, customer, invoice]   # l'icône à trois états (D444/D462)
 ```
+
+# Les graphiques
+
+## `chart.line`
+
+1. **Nom et famille** — `chart.line`, un graphique de la famille
+   pointée (D512) — la courbe ;
+2. **Rôle** — l'évolution d'un agrégat le long d'un axe : la tendance
+   d'un regard ;
+3. **Types servis** — aucun champ : **le graphique est une déclaration
+   autonome réutilisable** (D243) — sa source : une entité, un axe X,
+   un agrégat Y ;
+4. **Contexte consommé** — **X découpé par valeurs, par plages ou par
+   temporalité** (D240) ; **Y = un agrégat (D158) filtré sur X** ; la
+   confidentialité héritée de l'entité, surchargeable (D247) ; les
+   droits ;
+5. **Propriétés** — la déclaration (*les noms en proposition*) :
+   **`x:`** — le découpage (`date[month]` : le crochet temporel),
+   **`y:`** — l'agrégat (`sum(total)` — l'expression D90/D158),
+   `filter:` — le périmètre (D90), **`drill:`** — le drill-down
+   déclaré : la liste nommée au filtre imposé (D242 — « par défaut,
+   pas de drill-down ») ; `title:` (D493) ; *(en proposition : `y:`
+   accepte une liste — plusieurs séries sur le même axe ; les deux
+   axes restent à `chart.combo`, D239)* ;
+6. **Items** — aucun ;
+7. **Modes et déclinaisons** — **réutilisable** : le widget (associé à
+   une entité → le module fonctionnel — D247), le formulaire, le
+   tableau de bord (le rafraîchissement statique / temps réel /
+   fréquence — D249) ; **template** : l'image du graphique (D257) ;
+   tactile : le point touché montre sa valeur ;
+8. **États et interactions** — **le drill-down au clic** : le
+   graphique « enrichit le filtre de la liste pour imposer » les
+   éléments de la valeur cliquée (D242) ; la confidentialité masque ;
+9. **Décisions fondatrices** — D90, D158, D239–D243, D247–D249,
+   D512 ;
+10. **Exemple de configuration** —
+
+```yaml
+# sales/gui — le graphique, déclaration autonome (D243)
+charts:
+  revenue_by_month:
+    component: chart.line
+    title: { fr: Chiffre d'affaires }
+    x: date[month]               # le découpage temporel (D240)
+    y: sum(total)                # l'agrégat filtré sur X (D158)
+    filter: state = "invoiced"   # le périmètre (D90)
+    drill: invoiced              # la liste nommée au filtre imposé (D242)
+```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2321,11 +2321,11 @@ lists:
    conception et l'autorisation (`[pc paysage]` défaut — D450/D532) ;
    **`mode:`** — `read-only | updatable` (D453) ; **`history:`** —
    `false` désactive l'onglet historique d'une entité historisée
-   (D453) ; **`dimension:`** — la surimpression à l'appel, défaut
-   100 % de l'écran (D454 — l'extension D484, **la confusion
-   size/dimension levée par D534** : le formulaire s'ouvre → dimension,
-   la liste s'affiche → size ; la grammaire D533 : une ou deux
-   valeurs, % ou px) ;
+   (D453) ; **`size:`** — la surimpression, défaut 100 % de
+   l'écran (D454 amendé par **D535 : toute surface s'ouvre au-dessus
+   de la pile des actions antécédentes cumulées** — size pour toutes
+   les surfaces, le couple D484 restant au grain du champ ; la
+   grammaire D533 : une ou deux valeurs, % ou px) ;
 6. **Items** — **le `pages` implicite** (D509) : `header`, `page`(s),
    `footer` — les clés à l'usuel, **la liste d'éléments au
    multi-pages** (D510) ; dans les pages : les sections seules
@@ -2345,7 +2345,7 @@ lists:
    `title` en tête, vivant avec l'enregistrement ;
 9. **Décisions fondatrices** — D101, D111, D154, D196, D199, D203,
    D307, D437–D438, D446, D449–D455, D460, D465, D483, D509–D511,
-   D530, D533–D534 ;
+   D530, D533–D535 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -2354,7 +2354,7 @@ forms:
   default:                          # la première déclarée = le défaut (D438)
     title: "{number} — {customer}"  # le gabarit (D449) — le title de l'entité surchargé (D465)
     screen: [pc paysage]            # le support (D450)
-    dimension: 75%                  # la surimpression centrée (D454/D533)
+    size: 75%                       # la surimpression centrée sur la pile (D535/D533)
     header:
       items: [ field[number], field[state] ]
     page:                           # le pages implicite (D509)

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -1739,3 +1739,68 @@ forms:
     - page:   { items: [ field[lines] ] }
     - footer: { items: [ field[total] ] }
 ```
+
+# Les actes
+
+## `operation` (l'acte)
+
+1. **Nom et famille** — l'acte, **une fiche unique** : en items,
+   **`operation[<nom>]`** — « pour être en phase avec les fields »
+   (D511, l'écho de `field[<nom>]` D460 et `template[<nom>]` D483) ;
+   la matérialisation se déduit de l'habitat ;
+2. **Rôle** — **« l'utilisateur acte une opération »** (D456) : le
+   geste qui engage — le bouton, l'icône, le passage d'étape ;
+3. **Types servis** — les opérations du bloc `operations:` (D432 —
+   sans `when` : le bouton / la fonction API, D428) ; le changement
+   d'état du graphe (D425–D427, l'opération du catalogue par défaut —
+   D433) ;
+4. **Contexte consommé** — l'opération : sa garde (`if` — D430), ses
+   droits (D196), son `validate:` (D431) ; l'enregistrement ou la
+   sélection (l'opération de masse — D446) ; **la pré-exécution**
+   (D511) — les modifications à venir, chiffrées ;
+5. **Propriétés** — la surcharge de la présentation : `label:`,
+   `icon:`, `style:` (le verbe du catalogue en défaut) ;
+   **`validate:`** — `true` (défaut — la relecture D431) ou **le
+   message au gabarit nourri de la pré-exécution** (D511 — *écriture
+   en proposition :* `validate: { message: { fr: "{invoices}
+   factures seront créées" } }`, les variables = les résultats nommés
+   de la pré-exécution) ;
+6. **Items** — aucun ;
+7. **Modes et déclinaisons** — **l'habitat fait le visage** : le
+   formulaire → **le bouton** ; la colonne de liste → **l'icône à
+   trois états** (D444, le verbe au nom nu — D462) ; le wizard → **le
+   passage d'étape** (D504–D505, l'avance gardée) ; le menu →
+   l'adresse `<module>.<entité>.<opération>` (D439) ; **les deux
+   modes de l'opération** (D511) : la pré-exécution — « identifier
+   les modifications à apporter » — puis l'exécution réelle ;
+   template : jamais (le papier n'agit pas) ;
+8. **États et interactions** — **les trois états** (D444) :
+   actionnable / **non actionnable** (la garde grise le bouton, l'API
+   refuse proprement — D430) / **non visible** (les droits D196, la
+   confidentialité) ; la relecture avant engagement (D431 — lecture
+   seule + confirmer/annuler, jamais de popup D196) ; l'exécution
+   `synchronous`/`asynchronous`/`await` (D436) ;
+9. **Décisions fondatrices** — D196, D425–D433, D436, D439, D444,
+   D446, D456, D460, D462, D504–D505, D511 ;
+10. **Exemple de configuration** —
+
+```yaml
+# sales/entities/order.yml
+operations:
+  invoice:
+    validate:
+      message: { fr: "{invoices} factures seront créées" }  # le gabarit — la pré-exécution nourrit (D511)
+    effects:
+      - function: create_invoices
+
+gui:
+  forms:
+    default:
+      footer:
+        items:
+          - operation[invoice]:        # le bouton au formulaire (D511)
+              icon: invoice.svg
+  lists:
+    main:
+      columns: [number, customer, invoice]   # l'icône à trois états (D444/D462)
+```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -1841,8 +1841,10 @@ gui:
    acceptent `{ value:, min:, max:, scale: }` (les début et fin
    d'axe — l'écho D494 ; `scale: linear` défaut `| log`),
    **`colors:`** (la mécanique D467 — la couleur par série, le
-   dégradé), **`points:`** (les vignettes aux points — la valeur ;
-   le visage au nuage, D386) ; *(en proposition : `y:` accepte une
+   dégradé), **`labels:`** (D516) — `true` : la valeur au format du
+   champ ; **le gabarit** pour personnaliser (la collision avec le
+   dictionnaire D440 notée — le contexte départage, D458) ; le visage
+   au nuage (D386) ; *(en proposition : `y:` accepte une
    liste — plusieurs séries sur le même axe ; les deux axes restent à
    `chart.combo`, D239)* ;
 6. **Items** — aucun ;
@@ -1853,9 +1855,12 @@ gui:
    tactile : le point touché montre sa valeur ;
 8. **États et interactions** — **le drill-down au clic** : le
    graphique « enrichit le filtre de la liste pour imposer » les
-   éléments de la valeur cliquée (D242) ; la confidentialité masque ;
+   éléments de la valeur cliquée (D242) ; **le clic sur une
+   vignette** : « voir toutes les valeurs utilisées pour le calcul »
+   (D516 — si l'agrégat dépend d'une liste ou d'une association, le
+   détail des contributions s'ouvre) ; la confidentialité masque ;
 9. **Décisions fondatrices** — D90, D158, D239–D243, D247–D249,
-   D512, D515 ;
+   D512, D515–D516 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -1874,5 +1879,5 @@ charts:
     x: date[month]
     y: { value: avg(margin), min: 0, max: 100, scale: linear }
     colors: { serie: blue }      # la mécanique D467 — le dégradé possible
-    points: true                 # les vignettes aux points
+    labels: true                 # la valeur au format du champ (D516)
 ```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -44,8 +44,10 @@ matérialisation ; l'analogie des web components est consignée (D455).
   `thread` · `list` (l'éditeur du type liste) · `password` (la saisie
   masquée, D463) · `color` (la pastille — D496) — **le composant par défaut d'un type porte le nom du
   type** (D458) ;
-- **Les graphiques** : `chart` (courbe, barres, secteurs, combiné) ·
-  `kpi` · `pivot` — famille ouverte ;
+- **Les graphiques** : la famille pointée **`chart.line`** ·
+  **`chart.bars`** · **`chart.pie`** · **`chart.combo`** ·
+  **`chart.scatter`** (le nuage de points — D512) · `kpi` · `pivot` —
+  le hook étend (`chart.radar`…, D239) ; la jauge = la feuille `gauge` ;
 - **Les actes** : le bouton, l'icône, le passage d'étape — l'utilisateur
   acte une opération (D432/D444/D456).
 
@@ -1093,7 +1095,12 @@ gui:
    centrée au marqueur en lecture ; le pointage sur la carte en
    saisie (D294) ;
 3. **Types servis** — `geolocation` (le composé D391–D392 : les
-   coordonnées + le texte associé — l'adresse, le lieu) ;
+   coordonnées + le texte associé — l'adresse, le lieu) ; **la liste
+   de coordonnées** (`list of geolocation`, l'association aux
+   coordonnées) — « le composant doit pouvoir s'adapter » (D513) :
+   les marqueurs multiples sur une même carte, **les lignes possibles
+   ou pas** (le tracé dans l'ordre de la collection — *en
+   proposition : `lines: true | false`, défaut `false`*) ;
 4. **Contexte consommé** — la valeur (coordonnées et texte associé —
    D392), **le fond de carte déclaré à l'instance** (D259/D294), la
    focale (`focus:` au champ ou hérité du setting — D391), **la
@@ -1118,7 +1125,7 @@ gui:
    l'autorisation du terminal** (D291) ; grisé si `readonly`/droits ;
    le zoom et le déplacement au geste ;
 9. **Décisions fondatrices** — D125, D199, D257, D259, D291, D294,
-   D391–D392, D484 ;
+   D391–D392, D484, D513 ;
 10. **Exemple de configuration** —
 
 ```yaml

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -1829,9 +1829,10 @@ gui:
 2. **Rôle** — l'évolution d'un agrégat le long d'un axe : la tendance
    d'un regard ;
 3. **Types servis** — aucun champ : **le graphique est une déclaration
-   autonome réutilisable** (D243) — **son assise : une entité ou une
-   liste nommée** (le composant déjà vu — le périmètre, le filtre et
-   la confidentialité hérités), **les axes faisant référence aux
+   autonome réutilisable** (D243) — **son assise : une entité, une
+   liste nommée, ou un champ de type `list of` / `association with`**
+   (D517/D539 — le champ-collection : le graphique des éléments liés
+   à l'enregistrement du contexte), **les axes faisant référence aux
    champs de l'assise** (D517) ;
 4. **Contexte consommé** — **X découpé par valeurs, par plages ou par
    temporalité** (D240) ; **Y = un agrégat (D158) filtré sur X** ; la
@@ -1872,7 +1873,7 @@ gui:
    (D516 — si l'agrégat dépend d'une liste ou d'une association, le
    détail des contributions s'ouvre) ; la confidentialité masque ;
 9. **Décisions fondatrices** — D90, D158, D239–D244, D247–D249,
-   D439, D512, D515–D518, D521 ;
+   D439, D512, D515–D518, D521, D539 ;
 10. **Exemple de configuration** —
 
 ```yaml

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2238,7 +2238,9 @@ les widgets, le wizard, les templates, le dashboard du module).*
    **`actions:`** — la liste d'opérations (D531) : **l'opération
    porte son icône à la déclaration, la liste la surcharge** au
    besoin ; **`size:`** — « la zone de couverture de l'écran »
-   (D532 — la cohérence D484/D503) ; **`screen:`** — « le support sur
+   (D532) ; **la grammaire** (D533, vaut partout — D484) :
+   `size: 75%` — la part de l'écran, **centrée** ; `size: 90% 50%` —
+   la largeur puis la hauteur ; `size: 1000px 320px` — les pixels ; **`screen:`** — « le support sur
    lequel la liste a été définie et/ou autorisée à s'afficher »
    (D532/D450 — `[pc paysage]` en défaut) ; `title:` (D493) ;
 6. **Items** — aucun à déclarer : **l'anatomie est celle d'un
@@ -2265,7 +2267,7 @@ les widgets, le wizard, les templates, le dashboard du module).*
    sélectionnées (D446) ; les opérations en colonne à trois états
    (D444) ;
 9. **Décisions fondatrices** — D226–D229, D437–D448, D450, D462,
-   D466–D467, D484, D486, D492–D493, D530–D532 ;
+   D466–D467, D484, D486, D492–D493, D530–D533 ;
 10. **Exemple de configuration** —
 
 ```yaml

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2651,3 +2651,51 @@ wizards:
           items: [ field[channel] ]
           operation: print_menus   # l'opération à la validation du step (D546)
 ```
+
+## `dashboard`
+
+1. **Nom et famille** — `dashboard`, une surface — **au module** :
+   `module.yml`, bloc gui (*l'écriture `dashboards:` en
+   proposition*) ; le menu l'adresse — `module[dashboard]` (D439) ;
+   la première déclarée = le défaut (D438) ;
+2. **Rôle** — le tableau de bord : **la vue d'ensemble du module** —
+   les widgets et les graphiques de ses entités, assemblés ;
+3. **Types servis** — le module — ses entités au travers de leurs
+   widgets et charts (chacun sous sa confidentialité — D247) ;
+4. **Contexte consommé** — l'utilisateur (ses droits, sa
+   confidentialité — chaque widget filtre de lui-même), le module ;
+5. **Propriétés** — `title:` (D449/D465) ; `size:` (la pile D535 —
+   tout l'écran depuis le menu, l'esprit D549) ; `screen:`
+   (D450/D532) ; **le rafraîchissement** — les trois modes de D249
+   (*l'écriture en proposition :* `refresh: static | live |
+   every[5min]` — les durées D434/D476 ; surchargeable au widget, la
+   cascade D461) ;
+6. **Items** — **les widgets des entités du module** (*en
+   proposition :* `widget[<entité>.<nom>]` — la famille des adresses,
+   `widget[order.monthly]`) ; les graphiques directs
+   (`chart[<nom>]` — D243/D540) ; les `sections` et leurs layouts
+   pour la disposition (D489–D491) ;
+7. **Modes et déclinaisons** — **le dashboard déclaré ≠ la page
+   d'accueil composée** : l'accueil reste à l'utilisateur (D204 — le
+   pool des widgets de ses modules) ; le tableau de bord est l'œuvre
+   du technicien, au module ; le responsive au repli (D203) ;
+8. **États et interactions** — **le drill-down** de chaque widget
+   (D202/D242) ; la confidentialité masque widget par widget (D247) ;
+   le rafraîchissement vit selon son mode (D249) ;
+9. **Décisions fondatrices** — D202–D204, D242–D243, D247–D249,
+   D434, D438–D439, D449–D450, D455, D461, D465, D532, D535, D540 ;
+10. **Exemple de configuration** —
+
+```yaml
+# sales/module.yml, bloc gui — le tableau de bord du module (D439)
+dashboards:
+  main:                            # le menu : sales[main] (D439)
+    title: { fr: Pilotage des ventes }
+    refresh: every[5min]           # static | live | every[…] (D249/D434)
+    page:
+      - sections:
+          layout: column[2]
+          items:
+            - section: { items: [ widget[order.monthly] ] }
+            - section: { items: [ widget[customer.top10] ] }
+```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2087,3 +2087,43 @@ charts:
       - { value: count(),    as: line, axis: right }   # le volume en courbe
     labels: true
 ```
+
+## `kpi`
+
+1. **Nom et famille** — `kpi`, un graphique (D512 — à côté de la
+   famille pointée) — le chiffre-clé ;
+2. **Rôle** — un agrégat en grand : l'indicateur d'un regard ;
+3. **Types servis** — l'assise (D517–D518 : l'entité porteuse ou
+   `on:`) ; **la valeur = un agrégat (D158) — aucun axe** ;
+4. **Contexte consommé** — le socle des graphiques : la
+   confidentialité héritée surchargeable (D247), les droits ;
+5. **Propriétés** — `on:` (D517–D518), **`value:`** — l'agrégat
+   (*l'écho de `y:`, sans axe — en proposition*), `filter:` (D90),
+   `title:` (D493), `labels:` — le gabarit du format (D516,
+   `{value}`) ; **`colors:` par seuils** — le chiffre qui change de
+   couleur (la mécanique D467, la table d'entité D495 comprise) ;
+   `drill:` (D242) ; **pas de comparaison dans le socle** (D245 —
+   l'évolution contre une période = un hook) ;
+6. **Items** — aucun ;
+7. **Modes et déclinaisons** — **le widget roi** (l'entité → le
+   module fonctionnel — D247), le tableau de bord (le
+   rafraîchissement D249), le formulaire possible (D243) ;
+   **template** : la valeur au format ;
+8. **États et interactions** — le clic : le drill-down (D242) ou les
+   valeurs du calcul (D516) ; la confidentialité masque ;
+9. **Décisions fondatrices** — D158, D242–D243, D245, D247–D249,
+   D467, D495, D512, D515–D518 ;
+10. **Exemple de configuration** —
+
+```yaml
+# sales/entities/order.yml, bloc gui
+charts:
+  monthly_revenue:
+    component: kpi
+    value: sum(total)            # l'agrégat (D158) — aucun axe
+    filter: date in current_month
+    title: { fr: CA du mois }
+    labels: { fr: "{value} € HT" }
+    colors: { 0: red, 50000: orange, 100000: green }   # les seuils (D467)
+    drill: invoiced              # le clic : la liste (D242)
+```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -1948,8 +1948,13 @@ charts:
 5. **Propriétés** — **le socle commun** (D515–D518 : `on:`, `x:`,
    `y:`, `filter:`, `drill:`, `colors:`, `labels:`, `title:`) ; **les
    écarts propres** (D519) : **`mode: pie | donut | quarter`** — le
-   camembert (défaut), l'anneau, le quart de cercle (le crochet en
-   raccourci : `chart.pie[donut]`, D478) ; **les variables du
+   camembert (défaut), l'anneau, l'arc (le crochet en raccourci :
+   `chart.pie[donut]`, D478) ; **`thickness:`** — l'épaisseur de
+   l'anneau et de l'arc (D520 — *en proposition : le pourcentage du
+   rayon*) ; **les angles de `quarter`** — le départ et la fin, *en
+   proposition au crochet aux bornes* : `quarter[-90..90]` (0° à
+   midi, le sens horaire ; nu = `[0..90]`) — « représenter
+   l'assemblée nationale de la gauche vers la droite » (D520) ; **les variables du
    gabarit** des labels : `{value}`, `{percent}`, `{total}` —
    « {percent} % ({value} / {total}) » (D516/D519) ; **le
    regroupement des petites parts en « autres »** — un seuil, rien
@@ -1965,7 +1970,7 @@ charts:
    liste (D519) ; les valeurs du calcul (D516) ; la confidentialité
    masque ;
 9. **Décisions fondatrices** — D239–D243, D247–D249, D512, D515–D516,
-   D519 ;
+   D519–D520 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -1977,4 +1982,12 @@ charts:
     y: sum(total)
     labels: { fr: "{percent} % ({value} / {total})" }   # le trio (D519)
     drill: by_category              # le clic : la liste de la part (D242/D519)
+
+  assembly:                         # l'hémicycle (D520)
+    component: chart.pie
+    mode: quarter[-90..90]          # de la gauche vers la droite
+    thickness: 40%                  # l'épaisseur de l'arc
+    on: politics.deputy
+    x: party
+    y: count()
 ```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -1825,14 +1825,19 @@ gui:
 2. **Rôle** — l'évolution d'un agrégat le long d'un axe : la tendance
    d'un regard ;
 3. **Types servis** — aucun champ : **le graphique est une déclaration
-   autonome réutilisable** (D243) — sa source : une entité, un axe X,
-   un agrégat Y ;
+   autonome réutilisable** (D243) — **son assise : une entité ou une
+   liste nommée** (le composant déjà vu — le périmètre, le filtre et
+   la confidentialité hérités), **les axes faisant référence aux
+   champs de l'assise** (D517) ;
 4. **Contexte consommé** — **X découpé par valeurs, par plages ou par
    temporalité** (D240) ; **Y = un agrégat (D158) filtré sur X** ; la
    confidentialité héritée de l'entité, surchargeable (D247) ; les
    droits ;
 5. **Propriétés** — la déclaration (*les noms en proposition*) :
-   **`x:`** — le découpage (`date[month]` : le crochet temporel),
+   **`on:`** — l'assise à l'adresse (D517/D439) : `sales.order`
+   (l'entité) ou `sales.order[invoiced]` (la liste nommée, le crochet
+   de l'adresse) ; **`x:`** — le découpage d'un champ de l'assise
+   (`date[month]` : le crochet temporel),
    **`y:`** — l'agrégat (`sum(total)` — l'expression D90/D158),
    `filter:` — le périmètre (D90), **`drill:`** — le drill-down
    déclaré : la liste nommée au filtre imposé (D242 — « par défaut,
@@ -1860,7 +1865,7 @@ gui:
    (D516 — si l'agrégat dépend d'une liste ou d'une association, le
    détail des contributions s'ouvre) ; la confidentialité masque ;
 9. **Décisions fondatrices** — D90, D158, D239–D243, D247–D249,
-   D512, D515–D516 ;
+   D439, D512, D515–D517 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -1869,15 +1874,17 @@ charts:
   revenue_by_month:
     component: chart.line
     title: { fr: Chiffre d'affaires }
-    x: date[month]               # le découpage temporel (D240)
-    y: sum(total)                # l'agrégat filtré sur X (D158)
+    on: sales.order              # l'assise : l'entité (D517)
+    x: date[month]               # le champ, découpé (D240/D517)
+    y: sum(total)                # l'agrégat d'un champ (D158)
     filter: state = "invoiced"   # le périmètre (D90)
     drill: invoiced              # la liste nommée au filtre imposé (D242)
 
-  margin_by_month:               # la forme riche des axes (D515)
+  margin_by_month:
     component: chart.line
+    on: sales.order[invoiced]    # l'assise : la liste — le périmètre hérité (D517)
     x: date[month]
-    y: { value: avg(margin), min: 0, max: 100, scale: linear }
+    y: { value: avg(margin), min: 0, max: 100, scale: linear }   # (D515)
     colors: { serie: blue }      # la mécanique D467 — le dégradé possible
     labels: true                 # la valeur au format du champ (D516)
 ```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2237,7 +2237,10 @@ les widgets, le wizard, les templates, le dashboard du module).*
    `exports: [ csv, excel[stock.xlsx], template[order_sheet] ]` ;
    **`actions:`** — la liste d'opérations (D531) : **l'opération
    porte son icône à la déclaration, la liste la surcharge** au
-   besoin ; `title:` (D493) ;
+   besoin ; **`size:`** — « la zone de couverture de l'écran »
+   (D532 — la cohérence D484/D503) ; **`screen:`** — « le support sur
+   lequel la liste a été définie et/ou autorisée à s'afficher »
+   (D532/D450 — `[pc paysage]` en défaut) ; `title:` (D493) ;
 6. **Items** — aucun à déclarer : **l'anatomie est celle d'un
    `pages`** (D531 — intrinsèque) ;
 7. **Modes et déclinaisons** — **« une liste est comme pages »**
@@ -2261,8 +2264,8 @@ les widgets, le wizard, les templates, le dashboard du module).*
    décompte confirmé (D446/D530) ; **l'opération de masse** sur les lignes
    sélectionnées (D446) ; les opérations en colonne à trois états
    (D444) ;
-9. **Décisions fondatrices** — D226–D229, D437–D448, D462, D466–D467,
-   D486, D492–D493, D530–D531 ;
+9. **Décisions fondatrices** — D226–D229, D437–D448, D450, D462,
+   D466–D467, D484, D486, D492–D493, D530–D532 ;
 10. **Exemple de configuration** —
 
 ```yaml

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2336,7 +2336,9 @@ lists:
    multi-pages** (D510) ; dans les pages : les sections seules
    (D490), l'organisateur `sections`, les `tabs`, les feuilles
    (`field[<nom>]` — D460), les actes (`operation[<nom>]` — D511),
-   les documents (`template[<nom>]` — D483), les graphiques (D243) ;
+   les documents (`template[<nom>]` — D483), **les graphiques —
+   `chart[<nom>]` en feuille** (D243/D540, le résumé en héritant de
+   fait — D538) ;
 7. **Modes et déclinaisons** — **les cinq usages d'un seul
    formulaire** (D199) : la création (les compteurs « *(attribué à la
    validation)* » — D154/D199), la modification (la concurrence par

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2673,8 +2673,11 @@ wizards:
 6. **Items** — **le squelette** (D555) : **les widgets contraints**
    (*en proposition :* `widget[<entité>.<nom>]` — la famille des
    adresses, `widget[order.monthly]` — fixés, non retirables) et
-   **les emplacements libres** (*en proposition :* l'item **`free`**,
-   répétable — l'utilisateur y pioche du pool D247) ; les graphiques
+   **les emplacements libres** — l'item **`_`** (D556, acté — « free
+   pouvant être lui-même un nom de widget », la collision évitée),
+   répétable : **l'icône du choix** y apparaît, l'utilisateur pioche
+   parmi les widgets disponibles — son catalogue propre (le pool
+   D247) ou la libération d'un autre emplacement (D556) ; les graphiques
    directs (`chart[<nom>]` — D243/D540) ; les `sections` et leurs
    layouts pour la disposition (D489–D491) ;
 7. **Modes et déclinaisons** — **le même objet, deux auteurs**
@@ -2686,10 +2689,12 @@ wizards:
    libre** (D555) ; le responsive au repli (D203) ;
 8. **États et interactions** — **le drill-down** de chaque widget
    (D202/D242) ; la confidentialité masque widget par widget (D247) ;
-   le rafraîchissement vit selon son mode (D249) ;
+   le rafraîchissement vit selon son mode (D249) ; **l'emplacement
+   interchangeable porte son icône** — le choix, le remplacement, la
+   libération (D556) ;
 9. **Décisions fondatrices** — D191, D202–D204, D242–D243,
    D247–D249, D434, D438–D439, D449–D450, D455, D461, D465, D532,
-   D535, D540, D554–D555 ;
+   D535, D540, D554–D556 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -2703,5 +2708,5 @@ dashboards:
           layout: column[2]
           items:
             - section: { items: [ widget[order.monthly] ] }   # contraint (D555)
-            - section: { items: [ free ] }   # l'emplacement libre — le pool (D555)
+            - section: { items: [ _ ] }      # l'emplacement libre — le pool (D556)
 ```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2223,7 +2223,10 @@ charts:
    **« largeur × hauteur »** (`size: 200px 60px` — la grammaire
    D533) ; **la saisie peut porter sa propre taille** (D544 — *en
    proposition :* `size: { input: 30, display: 120px }`, la forme
-   courte valant l'affichage seul) ; **le format du code-barres au crochet** (*en
+   courte valant l'affichage seul) ; **`labels:`** — « la valeur de
+   la référence sous le code-barres » (D545 — *en proposition :*
+   `labels: true`, la valeur au format du champ — l'écho D516 ;
+   défaut `false`) ; **le format du code-barres au crochet** (*en
    proposition :* `barcode[ean13]`, `barcode[code128]` — le défaut
    `code128`) ;
 6. **Items** — aucun ;
@@ -2237,7 +2240,7 @@ charts:
 8. **États et interactions** — la lecture seule par nature ; masqué
    par la confidentialité ;
 9. **Décisions fondatrices** — D252, D300, D366, D369, D461, D484,
-   D533, D542–D544 ;
+   D516, D533, D542–D545 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -2256,6 +2259,7 @@ gui:
         - field[price]:
             component: barcode[ean13]   # le format au crochet (proposition)
             size: 200px 60px       # largeur × hauteur (D543)
+            labels: true           # la valeur sous les barres (D545)
 ```
 
 # Les surfaces

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -1099,8 +1099,12 @@ gui:
    de coordonnées** (`list of geolocation`, l'association aux
    coordonnées) — « le composant doit pouvoir s'adapter » (D513) :
    les marqueurs multiples sur une même carte, **les lignes possibles
-   ou pas** (le tracé dans l'ordre de la collection — *en
-   proposition : `lines: true | false`, défaut `false`*) ;
+   ou pas** (D513–D514 : « les lieux de commandes pour un produit » —
+   sans relier ; « le parcours d'un commercial » — relié **au trait
+   droit** ; *en proposition : `lines: true | false`, défaut
+   `false`*) ; **le tracé de la route = un hook** (« les abonnements
+   aux outils annexes » — le patron du géocodage D294, OSRM/Valhalla
+   en candidats open source, Q7) ;
 4. **Contexte consommé** — la valeur (coordonnées et texte associé —
    D392), **le fond de carte déclaré à l'instance** (D259/D294), la
    focale (`focus:` au champ ou hérité du setting — D391), **la
@@ -1125,7 +1129,7 @@ gui:
    l'autorisation du terminal** (D291) ; grisé si `readonly`/droits ;
    le zoom et le déplacement au geste ;
 9. **Décisions fondatrices** — D125, D199, D257, D259, D291, D294,
-   D391–D392, D484, D513 ;
+   D391–D392, D484, D513–D514 ;
 10. **Exemple de configuration** —
 
 ```yaml

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -1836,9 +1836,15 @@ gui:
    **`y:`** — l'agrégat (`sum(total)` — l'expression D90/D158),
    `filter:` — le périmètre (D90), **`drill:`** — le drill-down
    déclaré : la liste nommée au filtre imposé (D242 — « par défaut,
-   pas de drill-down ») ; `title:` (D493) ; *(en proposition : `y:`
-   accepte une liste — plusieurs séries sur le même axe ; les deux
-   axes restent à `chart.combo`, D239)* ;
+   pas de drill-down ») ; `title:` (D493) ; **les réglages
+   d'affichage** (D515) : **la forme riche des axes** — `x:`/`y:`
+   acceptent `{ value:, min:, max:, scale: }` (les début et fin
+   d'axe — l'écho D494 ; `scale: linear` défaut `| log`),
+   **`colors:`** (la mécanique D467 — la couleur par série, le
+   dégradé), **`points:`** (les vignettes aux points — la valeur ;
+   le visage au nuage, D386) ; *(en proposition : `y:` accepte une
+   liste — plusieurs séries sur le même axe ; les deux axes restent à
+   `chart.combo`, D239)* ;
 6. **Items** — aucun ;
 7. **Modes et déclinaisons** — **réutilisable** : le widget (associé à
    une entité → le module fonctionnel — D247), le formulaire, le
@@ -1849,7 +1855,7 @@ gui:
    graphique « enrichit le filtre de la liste pour imposer » les
    éléments de la valeur cliquée (D242) ; la confidentialité masque ;
 9. **Décisions fondatrices** — D90, D158, D239–D243, D247–D249,
-   D512 ;
+   D512, D515 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -1862,4 +1868,11 @@ charts:
     y: sum(total)                # l'agrégat filtré sur X (D158)
     filter: state = "invoiced"   # le périmètre (D90)
     drill: invoiced              # la liste nommée au filtre imposé (D242)
+
+  margin_by_month:               # la forme riche des axes (D515)
+    component: chart.line
+    x: date[month]
+    y: { value: avg(margin), min: 0, max: 100, scale: linear }
+    colors: { serie: blue }      # la mécanique D467 — le dégradé possible
+    points: true                 # les vignettes aux points
 ```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2712,3 +2712,71 @@ dashboards:
             - section: { items: [ widget[order.monthly] ] }   # contraint (D555)
             - section: { items: [ _ ] }      # l'emplacement libre — le pool (D556)
 ```
+
+## `template`
+
+1. **Nom et famille** — `template`, une surface — `gui: templates:
+   <nom>:` (l'ajout de l'auteur au catalogue — D456) ; la première
+   déclarée = le défaut (D438) ;
+2. **Rôle** — **le patron du document généré** : « un formulaire en
+   lecture seule + une dimension de page » (D250) — la facture, le
+   devis, l'étiquette, le bon de livraison ;
+3. **Types servis** — l'entité — l'enregistrement dans son agrégat ;
+   **les quatre portes** : l'effet `document:` d'une opération
+   (D432), le viewer à la volée (`template[<nom>]` — D483, « le
+   fichier qui n'existe pas »), les exports de la liste
+   (`exports: [ template[…] ]` — D530), **l'impression directe du
+   serveur** (D252 — les imprimantes de l'OS, l'étiquette) ;
+4. **Contexte consommé** — l'enregistrement ; **les variables de
+   contexte = l'entité « contexte »** (D254 — la pagination,
+   l'opérateur, l'instance : des champs comme les autres) ; la
+   langue — **un gabarit par langue** (D253 ; *l'écriture de la
+   déclinaison en proposition*) ;
+5. **Propriétés** — **le formalisme unique avec les formulaires**
+   (D250) : `title:` (le gabarit — D449), le `pages` implicite
+   (D509) ; **la dimension de page** (*en proposition :* `paper:` —
+   `A4`, `A4 landscape`, `105x48mm` pour l'étiquette) ; les titres à
+   quatre niveaux (D250) ;
+6. **Items** — le `pages` implicite : `header`/`footer` — **répétés à
+   chaque page** (la proposition de D507 confirmée par l'usage) —,
+   les `page`(s), les sections ; **les feuilles aux pendants PDF**
+   (D257 — « un pendant PDF par type » : l'image dimensionnée au
+   bloc, le fil complet si inclus…) ; **le contenu fixe** —
+   `paragraph`/`picture` (D488 — **le rendez-vous Q55 : les fiches à
+   étoffer ici**) ; `qrcode`/`barcode` (D542–D545 — l'étiquette) ;
+   les graphiques en image (D257) ;
+7. **Modes et déclinaisons** — le PDF d'abord (D212) ; jamais
+   d'interaction — le papier n'agit pas (l'écho D511) ; le viewer le
+   feuillette à l'écran (D481/D483) ;
+8. **États et interactions** — la lecture seule par nature (D250) ;
+   la confidentialité s'applique au rendu (les champs masqués
+   n'apparaissent pas) ;
+9. **Décisions fondatrices** — D212, D250–D254, D257, D432, D438,
+   D449, D481, D483, D488, D507, D509, D530, D542–D545 ;
+10. **Exemple de configuration** —
+
+```yaml
+# sales/entities/order.yml, bloc gui — le fil de la passe
+templates:
+  invoice:                         # document: invoice (D432) — template[invoice] (D483)
+    title: "Facture {number}"
+    paper: A4                      # la dimension de page (D250 — proposition)
+    header:
+      height: 40mm
+      items:
+        - picture: logo.png        # l'image fixe (D488)
+        - field[number]: { component: qrcode, size: 25mm }   # (D543)
+    page:
+      - field[customer]
+      - field[lines]               # la composition — le tableau
+      - paragraph: { label: legal }   # le texte fixe du dictionnaire (D440/D488)
+    footer:
+      height: 15mm
+      items: [ field[total] ]      # répété à chaque page (D507)
+
+  label:                           # l'étiquette (D252)
+    paper: 105x48mm
+    page:
+      - field[sku]: { component: qrcode, size: 30mm }
+      - field[name]
+```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2386,7 +2386,9 @@ forms:
    (D201) — le visage déployé d'une référence (D215), la carte qui se
    montre sans quitter le contexte ;
 3. **Types servis** — l'entité ; l'appel vient d'ailleurs : la
-   référence 1-1 (D186/D215 — le libellé, puis le résumé), le widget ;
+   référence 1-1 — **« le 1-1 affiche le title ou l'image si elle est
+   définie »** (D537, le visage D386), puis le résumé se déploie
+   (D186/D215) ; le widget ;
 4. **Contexte consommé** — l'enregistrement, l'origine de l'appel,
    l'utilisateur (D455) ; les droits (D196), la confidentialité ;
 5. **Propriétés** — **une config de formulaire restreinte** (D201) :
@@ -2394,17 +2396,20 @@ forms:
    (le `mode` au nœud — D461) ; `title:` (D449/D465) ; `size:` — la
    surimpression sur la pile, petite par principe (D535/D533) ;
    `screen:` (D450/D532) ;
-6. **Items** — la restriction du formulaire : les sections seules
-   (D490) et les feuilles — **« pas d'onglets, sections possibles »**
-   (D201) ; le `pages` implicite réduit à l'unique page ;
+6. **Items** — la restriction du formulaire : **plusieurs sections
+   possibles — « pour mêler des affichages horizontaux et
+   verticaux »** (D537 — l'organisateur `sections` et ses layouts,
+   D489–D491) et les feuilles ; **l'unique page, jamais d'onglets**
+   (D201/D537) ;
 7. **Modes et déclinaisons** — l'appel depuis la référence (D215 — le
    1-1 affiche le libellé, le résumé se déploie) ; la lecture seule
    et/ou la modification mêlées (D201) ; le responsive au repli
    (D203) ;
 8. **États et interactions** — les droits décident du modifiable ; la
    fermeture rend à la surface précédente (la pile — D535) ;
-9. **Décisions fondatrices** — D186, D196, D201, D203, D215,
-   D437–D438, D449–D450, D455, D461, D465, D490, D532–D533, D535 ;
+9. **Décisions fondatrices** — D186, D196, D201, D203, D215, D386,
+   D437–D438, D449–D450, D455, D461, D465, D489–D491, D532–D533,
+   D535, D537 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -2414,8 +2419,11 @@ summaries:
     title: "{name}"
     size: 30%                      # petit par principe (D201), centré (D533)
     page:
-      - field[name]
-      - field[phone]
+      - sections:
+          layout: row              # l'horizontal et le vertical mêlés (D537)
+          items:
+            - section: { items: [ field[photo] ] }
+            - section: { items: [ field[name], field[phone] ] }
       - field[balance]: { mode: read-only }   # le mêlé lecture/modification (D201)
 
 # et depuis la commande : field[customer] affiche le title (D465) ;

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2560,7 +2560,12 @@ widgets:
    déclarée = le défaut (D438) ;
 2. **Rôle** — **le parcours guidé : « mono-utilisateur, une
    session »** (D230) — les étapes s'enchaînent, la transaction
-   conclut ;
+   conclut ; **la démarche au sens large** (D546) : créer un
+   enregistrement, modifier ou supprimer **un ensemble répondant à
+   une liste**, imprimer (les menus : la semaine → la liste → la
+   diffusion), mettre à jour une tournée — le wizard orchestre les
+   opérations de l'entité (les quatre de base `create`/`read`/
+   `update`/`delete`, enrichies — D546) ;
 3. **Types servis** — l'entité — l'enregistrement en construction,
    dans son agrégat (D101) ;
 4. **Contexte consommé** — l'enregistrement transitoire, l'origine de
@@ -2572,12 +2577,15 @@ widgets:
    (D232/D101 — rien ne s'écrit avant la conclusion, la relecture
    D431 en clôture) ; **le brouillon = un niveau d'état déclaré,
    jamais une machinerie** (D233) ;
-6. **Items** — **les étapes** (*le couple en proposition :* `steps:`
-   / `step:` — le patron D489) : chaque étape porte sa poignée
-   (`title:`/`icon:` — le chemin D505), ses items (les sections, les
-   feuilles — la page d'un formulaire), et sa condition (*en
-   proposition :* **`if:`** — la transition conditionnelle D231/D90,
-   l'étape sautée si la condition ne tient pas) ;
+6. **Items** — **les étapes : `steps:`/`step:` — « un habillage de
+   `tabs[wizard]` où chaque step est en fait un tab »** (D546, le
+   couple acté) : chaque étape porte sa poignée (`title:`/`icon:` —
+   le chemin D505), ses items (les sections, les feuilles — la page
+   d'un formulaire), sa condition (*en proposition :* **`if:`** — la
+   transition conditionnelle D231/D90, l'étape sautée si la condition
+   ne tient pas), et **son opération** — « un step peut contenir une
+   opération sur la validation » (D546 — jouée au passage, l'acte
+   D511 ; *en proposition :* `operation: <nom>`) ;
 7. **Modes et déclinaisons** — **le squelette `tabs[wizard]`**
    (D504–D505) : toutes les étapes visibles, **l'avance au rythme de
    l'exploration**, « les tabs parcourus décrivent le chemin de
@@ -2593,7 +2601,8 @@ widgets:
    survit au niveau d'état déclaré D233 ; absent, la session
    emporte tout) ;
 9. **Décisions fondatrices** — D90, D101, D196, D230–D233, D431,
-   D438–D439, D449–D450, D455, D465, D504–D505, D511, D532, D535 ;
+   D438–D439, D449–D450, D455, D465, D504–D505, D511, D532, D535,
+   D546 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -2614,4 +2623,15 @@ wizards:
           title: { fr: Lignes }
           items: [ field[lines] ]
     validate: true                 # la relecture, puis la transaction finale (D232/D431)
+
+# catering/entities/menu.yml — l'impression guidée (D546)
+wizards:
+  print_week:
+    steps:
+      - step: { title: { fr: Semaine }, items: [ field[week] ] }
+      - step: { title: { fr: Menus },   items: [ field[menus] ] }
+      - step:
+          title: { fr: Diffusion }
+          items: [ field[channel] ]
+          operation: print_menus   # l'opération à la validation du step (D546)
 ```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2670,23 +2670,26 @@ wizards:
    (*l'écriture en proposition :* `refresh: static | live |
    every[5min]` — les durées D434/D476 ; surchargeable au widget, la
    cascade D461) ;
-6. **Items** — **les widgets des entités du module** (*en
-   proposition :* `widget[<entité>.<nom>]` — la famille des adresses,
-   `widget[order.monthly]`) ; les graphiques directs
-   (`chart[<nom>]` — D243/D540) ; les `sections` et leurs layouts
-   pour la disposition (D489–D491) ;
+6. **Items** — **le squelette** (D555) : **les widgets contraints**
+   (*en proposition :* `widget[<entité>.<nom>]` — la famille des
+   adresses, `widget[order.monthly]` — fixés, non retirables) et
+   **les emplacements libres** (*en proposition :* l'item **`free`**,
+   répétable — l'utilisateur y pioche du pool D247) ; les graphiques
+   directs (`chart[<nom>]` — D243/D540) ; les `sections` et leurs
+   layouts pour la disposition (D489–D491) ;
 7. **Modes et déclinaisons** — **le même objet, deux auteurs**
    (D554) : **le technicien déclare le panel** (les dashboards du
    module — le menu, l'accueil pointé) ; **l'utilisateur compose le
    sien** — la page d'accueil = un dashboard personnel, pioché dans
    le pool des widgets de ses modules, sous sa confidentialité
-   (D204/D247/D191) ; le responsive au repli (D203) ;
+   (D204/D247/D191) — **le cas limite du squelette entièrement
+   libre** (D555) ; le responsive au repli (D203) ;
 8. **États et interactions** — **le drill-down** de chaque widget
    (D202/D242) ; la confidentialité masque widget par widget (D247) ;
    le rafraîchissement vit selon son mode (D249) ;
 9. **Décisions fondatrices** — D191, D202–D204, D242–D243,
    D247–D249, D434, D438–D439, D449–D450, D455, D461, D465, D532,
-   D535, D540, D554 ;
+   D535, D540, D554–D555 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -2699,6 +2702,6 @@ dashboards:
       - sections:
           layout: column[2]
           items:
-            - section: { items: [ widget[order.monthly] ] }
-            - section: { items: [ widget[customer.top10] ] }
+            - section: { items: [ widget[order.monthly] ] }   # contraint (D555)
+            - section: { items: [ free ] }   # l'emplacement libre — le pool (D555)
 ```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -1947,21 +1947,25 @@ charts:
    héritée surchargeable (D247), les droits ;
 5. **Propriétés** — **le socle commun** (D515–D518 : `on:`, `x:`,
    `y:`, `filter:`, `drill:`, `colors:`, `labels:`, `title:`) ; **les
-   écarts propres** (*en proposition*) : **`mode: pie | donut`** — le
-   camembert (défaut) ou l'anneau (D239 ; le crochet en raccourci :
-   `chart.pie[donut]`, D478) ; **la variable `{percent}`** au gabarit
-   des labels (D516 — la part en pourcentage, à côté de `{value}`) ;
-   **le regroupement des petites parts en « autres »** — un seuil,
-   rien par défaut ;
+   écarts propres** (D519) : **`mode: pie | donut | quarter`** — le
+   camembert (défaut), l'anneau, le quart de cercle (le crochet en
+   raccourci : `chart.pie[donut]`, D478) ; **les variables du
+   gabarit** des labels : `{value}`, `{percent}`, `{total}` —
+   « {percent} % ({value} / {total}) » (D516/D519) ; **le
+   regroupement des petites parts en « autres »** — un seuil, rien
+   par défaut (D519) ;
 6. **Items** — aucun ;
 7. **Modes et déclinaisons** — réutilisable : le widget, le
    formulaire, le tableau de bord (D243/D249) ; **template** :
    l'image (D257) ; tactile : la part touchée montre sa valeur ;
-8. **États et interactions** — le drill-down au clic (D242) ; le clic
-   sur une part : les valeurs du calcul (D516) ; la confidentialité
+8. **États et interactions** — **le clic sur une part : la liste de
+   ses éléments** (D242/D519) ; **le drill d'« autres » à deux
+   étages** : une barre de répartition de toutes les autres valeurs
+   s'ouvre — l'utilisateur y précise la valeur à filtrer dans la
+   liste (D519) ; les valeurs du calcul (D516) ; la confidentialité
    masque ;
-9. **Décisions fondatrices** — D239–D243, D247–D249, D512,
-   D515–D518 ;
+9. **Décisions fondatrices** — D239–D243, D247–D249, D512, D515–D516,
+   D519 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -1971,6 +1975,6 @@ charts:
     component: chart.pie[donut]     # ≡ mode: donut — l'anneau (D239/D478)
     x: category                     # les parts (D240 — par valeurs)
     y: sum(total)
-    labels: { fr: "{percent} %" }   # le gabarit — {percent} (proposition)
-    drill: by_category              # la liste au filtre imposé (D242)
+    labels: { fr: "{percent} % ({value} / {total})" }   # le trio (D519)
+    drill: by_category              # le clic : la liste de la part (D242/D519)
 ```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2160,10 +2160,13 @@ charts:
    `[seller, customer]` : commercial › client) ; **`columns:`** — le
    ou les champs en colonne (le mot des listes D441) ; **`value:`** —
    la formule : un agrégat (D158) **partitionné par la cellule** ;
-   `filter:` (D90) ; **les plages et temporalités** sur les champs
-   numériques ou dates — « comme pour les graphiques (D240), pour
-   réduire le volume » : `date[month]`, les crochets ; `title:`
-   (D493) ;
+   `filter:` (D90) ; **`sort:`** — le tri sur la valeur :
+   « visualiser les plus gros CA » (D528 — *en proposition :*
+   `sort: -value`, le signe D441) — chaque niveau du groupement trié
+   par son sous-total, l'ordre naturel du champ en défaut ; **les
+   plages et temporalités** sur les champs numériques ou dates —
+   « comme pour les graphiques (D240), pour réduire le volume » :
+   `date[month]`, les crochets ; `title:` (D493) ;
 6. **Items** — aucun ;
 7. **Modes et déclinaisons** — **les groupements hiérarchiques,
    pliables au besoin** (D246) ; réutilisable : le widget (D247), le
@@ -2174,7 +2177,7 @@ charts:
    liste des éléments de l'intersection — l'écho D242/D519)* ; la
    confidentialité masque ;
 9. **Décisions fondatrices** — D134, D158, D240, D243, D246–D249,
-   D512, D517–D518 ;
+   D441, D512, D517–D518, D528 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -2185,6 +2188,7 @@ charts:
     rows: [seller, customer]     # la hiérarchie pliable — commercial › client
     columns: [date[month]]       # la temporalité (D240)
     value: sum(total)            # l'agrégat partitionné par la cellule (D158)
+    sort: -value                 # les plus gros CA d'abord (D528)
     filter: state = "invoiced"
     title: { fr: CA par commercial et par mois }
 ```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2227,8 +2227,14 @@ les widgets, le wizard, les templates, le dashboard du module).*
    champs ou les noms mutualisés — défaut : tous) ; `editable:`
    (**défaut : tout readonly** — D441) ; `selection: 1 | 1..`
    (D445–D446) ; `sizable: none | auto | manual | auto+manual`
-   (D447) ; **l'export** CSV (un fichier par type de composant) /
-   Excel (un onglet par type, le modèle, le tri d'export — D445) ;
+   (D447) ; **`add:` / `update:` / `delete:`** — « le
+   formulaire/widget à appeler » pour chaque geste (D530 — les
+   défauts : le formulaire par défaut D438, les gestes D446) ;
+   **`exports:`** — « les différents exports ou générations de
+   documents » (D530) : CSV (un fichier par type de composant), Excel
+   (l'onglet par type, le modèle, le tri d'export — D445), **le
+   template** (la génération — D483/D511) — *en proposition :*
+   `exports: [ csv, excel[stock.xlsx], template[order_sheet] ]` ;
    `title:` (D493) ;
 6. **Items** — aucun : la surface se déclare par ses propriétés ;
 7. **Modes et déclinaisons** — le tableau ou les widgets (D492) ; **le
@@ -2237,14 +2243,15 @@ les widgets, le wizard, les templates, le dashboard du module).*
    indicateurs de position ; l'embarquée d'une composition ou d'une
    association (D486) ; le responsive au repli (Q48) ;
 8. **États et interactions** — **la création : le bouton compris dans
-   le cadre** ; **la modification au double-clic** ; la lecture seule
-   → la consultation ; **la suppression** : une ligne = le formulaire
-   en lecture seule + la confirmation, plusieurs = le décompte
-   confirmé (D446) ; **l'opération de masse** sur les lignes
+   le cadre** — le formulaire d'`add:` (D530) ; **la modification au
+   double-clic** — celui d'`update:` ; la lecture seule → la
+   consultation ; **la suppression** : une ligne = le formulaire de
+   `delete:` en lecture seule + la confirmation, plusieurs = le
+   décompte confirmé (D446/D530) ; **l'opération de masse** sur les lignes
    sélectionnées (D446) ; les opérations en colonne à trois états
    (D444) ;
 9. **Décisions fondatrices** — D226–D229, D437–D448, D462, D466–D467,
-   D486, D492–D493 ;
+   D486, D492–D493, D530 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -2263,6 +2270,9 @@ lists:
     editable: [notes]              # le reste readonly (D441)
     selection: 1..                 # la multi-sélection (D446)
     sizable: auto+manual           # (D447)
+    add: quick_entry               # le formulaire du bouton + (D530)
+    update: default                # celui du double-clic — le défaut sinon (D438)
+    exports: [ csv, excel[orders.xlsx], template[order_sheet] ]   # (D530)
 
   cards:                           # le second visage (D492)
     widget: card                   # chaque enregistrement rendu par son widget

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2160,10 +2160,12 @@ charts:
    `[seller, customer]` : commercial › client) ; **`columns:`** — le
    ou les champs en colonne (le mot des listes D441) ; **`value:`** —
    la formule : un agrégat (D158) **partitionné par la cellule** ;
-   `filter:` (D90) ; **`sort:`** — le tri sur la valeur :
-   « visualiser les plus gros CA » (D528 — *en proposition :*
-   `sort: -value`, le signe D441) — chaque niveau du groupement trié
-   par son sous-total, l'ordre naturel du champ en défaut ; **les
+   `filter:` (D90) ; **`sort:`** — « le tri peut s'appuyer
+   sur les rows, les columns ou la value » (D528–D529) : la clé = un
+   champ des lignes, un champ des colonnes, ou `value` — les signes
+   et cascades D441 (`sort: { seller: -value, date: + }`) ; chaque
+   niveau du groupement trié par son sous-total, l'ordre naturel du
+   champ en défaut ; **les
    plages et temporalités** sur les champs numériques ou dates —
    « comme pour les graphiques (D240), pour réduire le volume » :
    `date[month]`, les crochets ; `title:` (D493) ;
@@ -2177,7 +2179,7 @@ charts:
    liste des éléments de l'intersection — l'écho D242/D519)* ; la
    confidentialité masque ;
 9. **Décisions fondatrices** — D134, D158, D240, D243, D246–D249,
-   D441, D512, D517–D518, D528 ;
+   D441, D512, D517–D518, D528–D529 ;
 10. **Exemple de configuration** —
 
 ```yaml

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2686,9 +2686,9 @@ wizards:
    sien** — la page d'accueil = un dashboard personnel, pioché dans
    le pool des widgets de ses modules, sous sa confidentialité
    (D204/D247/D191) — **le cas limite du squelette entièrement
-   libre** (D555) ; **« une page d'accueil fait référence à un
-   dashboard selon le module activé »** (D557) — le changement de
-   module change le tableau de bord ; le responsive au repli (D203) ;
+   libre** (D555) ; **la homepage pointe une liste, un dashboard ou une
+   page vide** (D558) — le dashboard suivant le module activé
+   (D557 : le changement de module change le tableau de bord) ; le responsive au repli (D203) ;
 8. **États et interactions** — **le drill-down** de chaque widget
    (D202/D242) ; la confidentialité masque widget par widget (D247) ;
    le rafraîchissement vit selon son mode (D249) ; **l'emplacement
@@ -2696,7 +2696,7 @@ wizards:
    libération (D556) ;
 9. **Décisions fondatrices** — D191, D202–D204, D242–D243,
    D247–D249, D434, D438–D439, D449–D450, D455, D461, D465, D532,
-   D535, D540, D554–D557 ;
+   D535, D540, D554–D558 ;
 10. **Exemple de configuration** —
 
 ```yaml

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2737,7 +2737,8 @@ dashboards:
    déclarée = le défaut (D438) ;
 2. **Rôle** — **le patron du document généré** : « un formulaire en
    lecture seule + une dimension de page » (D250) — la facture, le
-   devis, l'étiquette, le bon de livraison ;
+   devis, l'étiquette, le bon de livraison — **vers quatre
+   destinations : « Word, PDF, Excel ou un mail »** (D564) ;
 3. **Types servis** — l'entité — l'enregistrement dans son agrégat ;
    **les quatre portes** : l'effet `document:` d'une opération
    (D432), le viewer à la volée (`template[<nom>]` — D483, « le
@@ -2754,8 +2755,11 @@ dashboards:
    (D250) : `title:` (le gabarit — D449), le `pages` implicite
    (D509) ; **la dimension de page** (*en proposition :* `paper:` —
    `A4`, `A4 landscape`, `105x48mm` pour l'étiquette) ; **`margin:`**
-   — « les marges en mm » (D559) ; les titres à quatre niveaux
-   (D250) ;
+   — « les marges en mm » (D559) ; **`format:`** — « le format de
+   destination » (D564) : `pdf` (*le défaut en proposition* — la
+   lignée D212/D250) `| word | excel | mail` — le mail portant le
+   publipostage (D562), l'Excel le modèle (D445) ; les titres à
+   quatre niveaux (D250) ;
 6. **Items** — le `pages` implicite : `header`/`footer` — **répétés à
    chaque page** (la proposition de D507 confirmée par l'usage) —,
    les `page`(s), les sections ; **les feuilles aux pendants PDF**
@@ -2771,7 +2775,8 @@ dashboards:
    la confidentialité s'applique au rendu (les champs masqués
    n'apparaissent pas) ;
 9. **Décisions fondatrices** — D212, D250–D254, D257, D432, D438,
-   D449, D481, D483, D488, D507, D509, D530, D542–D545, D559 ;
+   D445, D449, D481, D483, D488, D507, D509, D530, D542–D545, D559,
+   D562, D564 ;
 10. **Exemple de configuration** —
 
 ```yaml

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -1411,7 +1411,11 @@ page:                              # la section seule, directement (D490)
    informations légales de l'entreprise » ;
 2. **Rôle** — le texte venu de la configuration, affiché tel quel —
    **aucun champ derrière** : la mention, l'explication,
-   l'avertissement ;
+   l'avertissement ; **et le gabarit** — « le paragraph peut être un
+   gabarit, utilisable dans le cas d'une lettre » (D559,
+   l'étoffement Q55) : les variables de l'enregistrement dans le
+   texte (« Cher {customer}, votre commande {number}… ») — le
+   publipostage ;
 3. **Types servis** — aucun : le contenu est déclaré, par langue
    (D465) ou par référence au dictionnaire du module (`labels` —
    D440) ;
@@ -1427,7 +1431,7 @@ page:                              # la section seule, directement (D490)
    étoffée au point gabarit / génération de documents (Q55)* ;
 8. **États et interactions** — la visibilité par les droits ; rien
    d'autre — le texte ne se clique pas ;
-9. **Décisions fondatrices** — D440, D455, D461, D465, D488 ;
+9. **Décisions fondatrices** — D440, D455, D461, D465, D488, D559 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -2730,13 +2734,15 @@ dashboards:
 4. **Contexte consommé** — l'enregistrement ; **les variables de
    contexte = l'entité « contexte »** (D254 — la pagination,
    l'opérateur, l'instance : des champs comme les autres) ; la
-   langue — **un gabarit par langue** (D253 ; *l'écriture de la
-   déclinaison en proposition*) ;
+   langue — **« la déclinaison par langue se porte sur chaque item »**
+   (D559, amende la lecture de D253) : un seul gabarit, ses items
+   déclinés (la mécanique D465) ;
 5. **Propriétés** — **le formalisme unique avec les formulaires**
    (D250) : `title:` (le gabarit — D449), le `pages` implicite
    (D509) ; **la dimension de page** (*en proposition :* `paper:` —
-   `A4`, `A4 landscape`, `105x48mm` pour l'étiquette) ; les titres à
-   quatre niveaux (D250) ;
+   `A4`, `A4 landscape`, `105x48mm` pour l'étiquette) ; **`margin:`**
+   — « les marges en mm » (D559) ; les titres à quatre niveaux
+   (D250) ;
 6. **Items** — le `pages` implicite : `header`/`footer` — **répétés à
    chaque page** (la proposition de D507 confirmée par l'usage) —,
    les `page`(s), les sections ; **les feuilles aux pendants PDF**
@@ -2752,7 +2758,7 @@ dashboards:
    la confidentialité s'applique au rendu (les champs masqués
    n'apparaissent pas) ;
 9. **Décisions fondatrices** — D212, D250–D254, D257, D432, D438,
-   D449, D481, D483, D488, D507, D509, D530, D542–D545 ;
+   D449, D481, D483, D488, D507, D509, D530, D542–D545, D559 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -2761,6 +2767,7 @@ templates:
   invoice:                         # document: invoice (D432) — template[invoice] (D483)
     title: "Facture {number}"
     paper: A4                      # la dimension de page (D250 — proposition)
+    margin: 15mm                   # les marges (D559)
     header:
       height: 40mm
       items:

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2009,12 +2009,14 @@ charts:
 4. **Contexte consommé** — le socle des `chart.*` (la confidentialité
    D247, les droits) ; **le visage de l'enregistrement** (D386) ;
 5. **Propriétés** — **le socle commun** (D515–D518, D521 — `display:`
-   compris) ; **les écarts propres** (D522, *écritures en
-   proposition*) : **`thresholds:`** dans la forme riche de l'axe —
-   la liste croissante de seuils, « qui ne se chevauchent pas » par
-   construction — les bandes ; **`zones:`** — la zone au croisement
-   des bandes (`x: 0..50` aux bornes D366, `title:` D493, `color:`
-   D496) : le MoSCoW à deux critères, l'effort/bénéfice ;
+   compris) ; **les écarts propres** (D522–D523) :
+   **`threshold:`** dans la forme riche de l'axe — « l'axe définit
+   min, max et threshold » : la liste croissante des seuils, les
+   bandes ; **`zones:`** — la zone **s'adresse dans la matrice
+   créée** : `zone: [1,1]` + `title:` (+ `color:`) — plus aucune
+   borne répétée (D523 ; *la convention en proposition :
+   `[colonne, ligne]` depuis l'origine des axes, `[1,1]` en bas à
+   gauche*) : le MoSCoW à deux critères, l'effort/bénéfice ;
 6. **Items** — aucun ;
 7. **Modes et déclinaisons** — réutilisable (D243/D249) ; template :
    l'image (D257) ; **le survol** : le visage de l'enregistrement
@@ -2024,7 +2026,7 @@ charts:
    liste de ses éléments** (l'écho D519) ; la confidentialité
    masque ;
 9. **Décisions fondatrices** — D239–D243, D247–D249, D386, D512,
-   D515–D518, D521–D522 ;
+   D515–D518, D521–D523 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -2032,12 +2034,12 @@ charts:
 charts:
   priorities:
     component: chart.scatter
-    x: { value: effort,  min: 0, max: 100, thresholds: [50] }
-    y: { value: benefit, min: 0, max: 100, thresholds: [50] }
-    zones:
-      - { x: 0..50,   y: 50..100, title: { fr: Gains rapides }, color: green }
-      - { x: 50..100, y: 50..100, title: { fr: Grands projets }, color: orange }
-      - { x: 0..50,   y: 0..50,   title: { fr: Tâches de fond }, color: gray }
-      - { x: 50..100, y: 0..50,   title: { fr: À éviter },      color: red }
+    x: { value: effort,  min: 0, max: 100, threshold: [50] }   # les bandes (D523)
+    y: { value: benefit, min: 0, max: 100, threshold: [50] }
+    zones:                        # la position dans la matrice — [colonne, ligne] (D523)
+      - { zone: [1,2], title: { fr: Gains rapides }, color: green }
+      - { zone: [2,2], title: { fr: Grands projets }, color: orange }
+      - { zone: [1,1], title: { fr: Tâches de fond }, color: gray }
+      - { zone: [2,1], title: { fr: À éviter },      color: red }
     labels: true                  # le visage au survol (D386)
 ```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2140,3 +2140,51 @@ charts:
     layout: left                 # le label à gauche, l'icône à droite (D527)
     drill: invoiced              # le clic : la liste (D242)
 ```
+
+## `pivot`
+
+1. **Nom et famille** — `pivot`, un graphique (D512 — à côté de la
+   famille pointée) — le croisé dynamique ;
+2. **Rôle** — **« un outil d'analyse puissant et pourtant simple à
+   mettre en œuvre »** (D246) : les lignes croisent les colonnes, la
+   formule remplit l'intersection ;
+3. **Types servis** — l'assise (D517–D518) ; **les quatre éléments**
+   (D246) : un filtre, le ou les champs en ligne, le ou les champs en
+   colonne, une formule à l'intersection ;
+4. **Contexte consommé** — la confidentialité héritée surchargeable
+   (D247), les droits ; **indépendant des compositions matricielles**
+   (D134) — le croisé est une présentation, applicable à toute
+   entité ;
+5. **Propriétés** — (*les noms en proposition*) : **`rows:`** — le ou
+   les champs en ligne (la liste = le groupement hiérarchique,
+   `[seller, customer]` : commercial › client) ; **`columns:`** — le
+   ou les champs en colonne (le mot des listes D441) ; **`value:`** —
+   la formule : un agrégat (D158) **partitionné par la cellule** ;
+   `filter:` (D90) ; **les plages et temporalités** sur les champs
+   numériques ou dates — « comme pour les graphiques (D240), pour
+   réduire le volume » : `date[month]`, les crochets ; `title:`
+   (D493) ;
+6. **Items** — aucun ;
+7. **Modes et déclinaisons** — **les groupements hiérarchiques,
+   pliables au besoin** (D246) ; réutilisable : le widget (D247), le
+   tableau de bord (D249), le formulaire (D243) ; **template** : le
+   tableau rendu, groupements dépliés ;
+8. **États et interactions** — **le pli et le dépli** des
+   groupements ; *(en proposition : le clic sur une cellule ouvre la
+   liste des éléments de l'intersection — l'écho D242/D519)* ; la
+   confidentialité masque ;
+9. **Décisions fondatrices** — D134, D158, D240, D243, D246–D249,
+   D512, D517–D518 ;
+10. **Exemple de configuration** —
+
+```yaml
+# sales/entities/order.yml, bloc gui — l'exemple fondateur de D246
+charts:
+  revenue_matrix:
+    component: pivot
+    rows: [seller, customer]     # la hiérarchie pliable — commercial › client
+    columns: [date[month]]       # la temporalité (D240)
+    value: sum(total)            # l'agrégat partitionné par la cellule (D158)
+    filter: state = "invoiced"
+    title: { fr: CA par commercial et par mois }
+```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2589,7 +2589,8 @@ widgets:
    **les étapes : `steps:`/`step:` — « un habillage de `tabs[wizard]`
    où chaque step est en fait un tab »** (D546, le couple acté) : chaque étape porte sa poignée (`title:`/`icon:` —
    le chemin D505), ses items (les sections, les feuilles — la page
-   d'un formulaire), sa condition (*en proposition :* **`if:`** — la
+   d'un formulaire — **et les graphiques : `chart[<nom>]`, kpi,
+   pivot, « l'aide à la décision »**, D550), sa condition (*en proposition :* **`if:`** — la
    transition conditionnelle D231/D90, l'étape sautée si la condition
    ne tient pas), et **son opération** — « un step peut contenir une
    opération sur la validation » (D546 — *en proposition :*
@@ -2613,7 +2614,7 @@ widgets:
    l'interruption emporte le transitoire (D547 — le draft effacé) ;
 9. **Décisions fondatrices** — D90, D101, D196, D230–D233, D431,
    D438–D439, D449–D450, D455, D465, D504–D505, D507, D511, D525,
-   D532–D533, D535, D546–D549 ;
+   D532–D533, D535, D540, D546–D550 ;
 10. **Exemple de configuration** —
 
 ```yaml

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2552,3 +2552,66 @@ widgets:
       - chart[monthly_revenue]     # le kpi (D540)
       - chart[revenue_by_month]    # la courbe — le drill vers la liste (D202/D242)
 ```
+
+## `wizard`
+
+1. **Nom et famille** — `wizard`, une surface — `gui: wizards:
+   <nom>:` ; le menu l'adresse (`[@wizard]` — D439) ; la première
+   déclarée = le défaut (D438) ;
+2. **Rôle** — **le parcours guidé : « mono-utilisateur, une
+   session »** (D230) — les étapes s'enchaînent, la transaction
+   conclut ;
+3. **Types servis** — l'entité — l'enregistrement en construction,
+   dans son agrégat (D101) ;
+4. **Contexte consommé** — l'enregistrement transitoire, l'origine de
+   l'appel, l'utilisateur (D455) ; les droits (D196) ;
+5. **Propriétés** — `title:` (D449/D465) ; `size:` (la pile — D535) ;
+   `screen:` (D450/D532) ; **les étapes = des surfaces déclarées**
+   (D231) ; **les transitions conditionnelles** — « si client
+   étranger → étape TVA » (D231/D90) ; **la transaction finale**
+   (D232/D101 — rien ne s'écrit avant la conclusion, la relecture
+   D431 en clôture) ; **le brouillon = un niveau d'état déclaré,
+   jamais une machinerie** (D233) ;
+6. **Items** — **les étapes** (*le couple en proposition :* `steps:`
+   / `step:` — le patron D489) : chaque étape porte sa poignée
+   (`title:`/`icon:` — le chemin D505), ses items (les sections, les
+   feuilles — la page d'un formulaire), et sa condition (*en
+   proposition :* **`if:`** — la transition conditionnelle D231/D90,
+   l'étape sautée si la condition ne tient pas) ;
+7. **Modes et déclinaisons** — **le squelette `tabs[wizard]`**
+   (D504–D505) : toutes les étapes visibles, **l'avance au rythme de
+   l'exploration**, « les tabs parcourus décrivent le chemin de
+   traitement » — le retour libre d'un clic ; **le passage d'étape =
+   un acte** (D511) ; emboîtable — « rien n'empêche un formulaire
+   qui inclut un wizard dans une page » (D455) ; le circuit de
+   validation multi-acteurs reste **hors wizard** — le patron
+   d'assemblage états + opérations + notifications, sans moteur BPM
+   (D233) ;
+8. **États et interactions** — **l'état transitoire** jusqu'à la
+   transaction finale (D232/D101) ; l'interruption : **le brouillon
+   déclaré** (*en proposition :* `draft: <état>` — l'enregistrement
+   survit au niveau d'état déclaré D233 ; absent, la session
+   emporte tout) ;
+9. **Décisions fondatrices** — D90, D101, D196, D230–D233, D431,
+   D438–D439, D449–D450, D455, D465, D504–D505, D511, D532, D535 ;
+10. **Exemple de configuration** —
+
+```yaml
+# sales/entities/order.yml, bloc gui
+wizards:
+  new_order:                       # le menu : sales.order[@new_order] (D439)
+    title: { fr: Nouvelle commande }
+    draft: draft                   # l'interruption survit à l'état déclaré (D233)
+    steps:
+      - step:
+          title: { fr: Client }
+          items: [ field[customer] ]
+      - step:
+          title: { fr: TVA }
+          if: customer.country != "FR"   # la transition conditionnelle (D231/D90)
+          items: [ field[vat_number] ]
+      - step:
+          title: { fr: Lignes }
+          items: [ field[lines] ]
+    validate: true                 # la relecture, puis la transaction finale (D232/D431)
+```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -1846,6 +1846,8 @@ gui:
    d'affichage** (D515) : **la forme riche des axes** — `x:`/`y:`
    acceptent `{ value:, min:, max:, scale: }` (les début et fin
    d'axe — l'écho D494 ; `scale: linear` défaut `| log`),
+   **`display: graph | table | both`** — le graphique, le tableau des
+   valeurs, ou les deux (D521 — l'écho D244 ; défaut `graph`),
    **`colors:`** (la mécanique D467 — la couleur par série, le
    dégradé), **`labels:`** (D516) — `true` : la valeur au format du
    champ ; **le gabarit** pour personnaliser (la collision avec le
@@ -1865,8 +1867,8 @@ gui:
    vignette** : « voir toutes les valeurs utilisées pour le calcul »
    (D516 — si l'agrégat dépend d'une liste ou d'une association, le
    détail des contributions s'ouvre) ; la confidentialité masque ;
-9. **Décisions fondatrices** — D90, D158, D239–D243, D247–D249,
-   D439, D512, D515–D518 ;
+9. **Décisions fondatrices** — D90, D158, D239–D244, D247–D249,
+   D439, D512, D515–D518, D521 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -1902,10 +1904,11 @@ charts:
    possibles ;
 4. **Contexte consommé** — le socle des `chart.*` : la confidentialité
    héritée surchargeable (D247), les droits ;
-5. **Propriétés** — **le socle commun** (D515–D518) : `on:`, `x:`,
-   `y:` (la forme riche — et la liste : plusieurs séries), `filter:`,
-   `drill:`, `colors:`, `labels:`, `title:` ; **les écarts propres**
-   (*en proposition*) : **`mode: vertical | horizontal`** (défaut
+5. **Propriétés** — **le socle commun** (D515–D518, D521 — `display:`
+   compris) : `on:`, `x:`, `y:` (la forme riche — et la liste :
+   plusieurs séries), `filter:`, `drill:`, `colors:`, `labels:`,
+   `title:` ; **les écarts propres** (*en proposition*) :
+   **`mode: vertical | horizontal`** (défaut
    vertical — le crochet en raccourci : `chart.bars[horizontal]`,
    D478) ; **`stacked:`** — les séries empilées (`true`), côte à côte
    sinon (défaut) ;
@@ -1945,9 +1948,9 @@ charts:
    valeurs** (les parts — D240), `y:` = l'agrégat qui mesure la part ;
 4. **Contexte consommé** — le socle des `chart.*` : la confidentialité
    héritée surchargeable (D247), les droits ;
-5. **Propriétés** — **le socle commun** (D515–D518 : `on:`, `x:`,
-   `y:`, `filter:`, `drill:`, `colors:`, `labels:`, `title:`) ; **les
-   écarts propres** (D519) : **`mode: pie | donut | quarter`** — le
+5. **Propriétés** — **le socle commun** (D515–D518, D521 —
+   `display:` compris) : `on:`, `x:`, `y:`, `filter:`, `drill:`,
+   `colors:`, `labels:`, `title:` ; **les écarts propres** (D519) : **`mode: pie | donut | quarter`** — le
    camembert (défaut), l'anneau, l'arc (le crochet en raccourci :
    `chart.pie[donut]`, D478) ; **`thickness:`** — l'épaisseur de
    l'anneau et de l'arc (D520 — *en proposition : le pourcentage du

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2217,9 +2217,13 @@ charts:
    (`component: qrcode`) ;
 4. **Contexte consommé** — le champ, sa valeur convertie (D369), les
    droits ;
-5. **Propriétés** — le socle (D461) ; `size:` (D484/D533) ; **le
-   format du code-barres au crochet** (*en proposition :*
-   `barcode[ean13]`, `barcode[code128]` — le défaut `code128`) ;
+5. **Propriétés** — le socle (D461) ; **`size:` aux deux régimes**
+   (D543) : le qrcode — **« la taille unique pour les côtés »**
+   (`size: 120px`, le carré — jamais deux valeurs) ; le code-barres —
+   **« largeur × hauteur »** (`size: 200px 60px` — la grammaire
+   D533) ; **le format du code-barres au crochet** (*en
+   proposition :* `barcode[ean13]`, `barcode[code128]` — le défaut
+   `code128`) ;
 6. **Items** — aucun ;
 7. **Modes et déclinaisons** — **la sortie d'abord** : le PDF et
    l'étiquette (D252 — l'impression directe du serveur, les
@@ -2228,7 +2232,8 @@ charts:
    question pour plus tard si besoin*) ;
 8. **États et interactions** — la lecture seule par nature ; masqué
    par la confidentialité ;
-9. **Décisions fondatrices** — D252, D300, D369, D461, D484, D542 ;
+9. **Décisions fondatrices** — D252, D300, D369, D461, D484, D533,
+   D542–D543 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -2242,9 +2247,11 @@ gui:
       page:
         - field[sku]:
             component: qrcode      # la valeur rendue en QR (D300)
+            size: 120px            # le carré — 120 px de côté (D543)
         - field[name]
         - field[price]:
             component: barcode[ean13]   # le format au crochet (proposition)
+            size: 200px 60px       # largeur × hauteur (D543)
 ```
 
 # Les surfaces

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2756,9 +2756,11 @@ dashboards:
    (D509) ; **la dimension de page** (*en proposition :* `paper:` —
    `A4`, `A4 landscape`, `105x48mm` pour l'étiquette) ; **`margin:`**
    — « les marges en mm » (D559) ; **`format:`** — « le format de
-   destination » (D564) : `pdf` (*le défaut en proposition* — la
-   lignée D212/D250) `| word | excel | mail` — le mail portant le
-   publipostage (D562), l'Excel le modèle (D445) ; les titres à
+   destination » (D564–D565) : `pdf` (**le défaut acté** — la lignée
+   D212/D250) `| word | excel | mail` — le mail portant le
+   publipostage (D562), l'Excel le modèle (D445) ; **« étendu à
+   d'autres formats en fonction des besoins à venir »** (D565 — la
+   ligne des hooks D408) ; les titres à
    quatre niveaux (D250) ;
 6. **Items** — le `pages` implicite : `header`/`footer` — **répétés à
    chaque page** (la proposition de D507 confirmée par l'usage) —,

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2322,8 +2322,10 @@ lists:
    **`mode:`** — `read-only | updatable` (D453) ; **`history:`** —
    `false` désactive l'onglet historique d'une entité historisée
    (D453) ; **`dimension:`** — la surimpression à l'appel, défaut
-   100 % de l'écran (D454 — l'extension D484 ; la grammaire D533 :
-   une ou deux valeurs, % ou px) ;
+   100 % de l'écran (D454 — l'extension D484, **la confusion
+   size/dimension levée par D534** : le formulaire s'ouvre → dimension,
+   la liste s'affiche → size ; la grammaire D533 : une ou deux
+   valeurs, % ou px) ;
 6. **Items** — **le `pages` implicite** (D509) : `header`, `page`(s),
    `footer` — les clés à l'usuel, **la liste d'éléments au
    multi-pages** (D510) ; dans les pages : les sections seules
@@ -2343,7 +2345,7 @@ lists:
    `title` en tête, vivant avec l'enregistrement ;
 9. **Décisions fondatrices** — D101, D111, D154, D196, D199, D203,
    D307, D437–D438, D446, D449–D455, D460, D465, D483, D509–D511,
-   D530, D533 ;
+   D530, D533–D534 ;
 10. **Exemple de configuration** —
 
 ```yaml

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -1836,7 +1836,8 @@ gui:
 5. **Propriétés** — la déclaration (*les noms en proposition*) :
    **`on:`** — l'assise à l'adresse (D517/D439) : `sales.order`
    (l'entité) ou `sales.order[invoiced]` (la liste nommée, le crochet
-   de l'adresse) ; **`x:`** — le découpage d'un champ de l'assise
+   de l'adresse) — **absent : l'entité porteuse de la déclaration**
+   (D518) ; **`x:`** — le découpage d'un champ de l'assise
    (`date[month]` : le crochet temporel),
    **`y:`** — l'agrégat (`sum(total)` — l'expression D90/D158),
    `filter:` — le périmètre (D90), **`drill:`** — le drill-down
@@ -1865,16 +1866,16 @@ gui:
    (D516 — si l'agrégat dépend d'une liste ou d'une association, le
    détail des contributions s'ouvre) ; la confidentialité masque ;
 9. **Décisions fondatrices** — D90, D158, D239–D243, D247–D249,
-   D439, D512, D515–D517 ;
+   D439, D512, D515–D518 ;
 10. **Exemple de configuration** —
 
 ```yaml
-# sales/gui — le graphique, déclaration autonome (D243)
+# sales/entities/order.yml, bloc gui — la déclaration autonome (D243)
 charts:
   revenue_by_month:
     component: chart.line
     title: { fr: Chiffre d'affaires }
-    on: sales.order              # l'assise : l'entité (D517)
+                                 # on: absent — l'assise : l'entité porteuse (D518)
     x: date[month]               # le champ, découpé (D240/D517)
     y: sum(total)                # l'agrégat d'un champ (D158)
     filter: state = "invoiced"   # le périmètre (D90)

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2221,19 +2221,23 @@ charts:
    (D543) : le qrcode — **« la taille unique pour les côtés »**
    (`size: 120px`, le carré — jamais deux valeurs) ; le code-barres —
    **« largeur × hauteur »** (`size: 200px 60px` — la grammaire
-   D533) ; **le format du code-barres au crochet** (*en
+   D533) ; **la saisie peut porter sa propre taille** (D544 — *en
+   proposition :* `size: { input: 30, display: 120px }`, la forme
+   courte valant l'affichage seul) ; **le format du code-barres au crochet** (*en
    proposition :* `barcode[ean13]`, `barcode[code128]` — le défaut
    `code128`) ;
 6. **Items** — aucun ;
-7. **Modes et déclinaisons** — **la sortie d'abord** : le PDF et
-   l'étiquette (D252 — l'impression directe du serveur, les
-   imprimantes de l'OS), l'écran en lecture ; **Excel = la valeur
-   source** (D300) ; jamais la saisie (*le scan reste hors D300 — la
-   question pour plus tard si besoin*) ;
+7. **Modes et déclinaisons** — **les deux modes du champ** (D544) :
+   **la saisie en mode texte** — la zone du champ, son régime (la
+   taille D366, le masque) — et **l'affichage en mode graphique** ;
+   le PDF et l'étiquette en usage premier (D252 — l'impression
+   directe du serveur, les imprimantes de l'OS) ; **Excel = la valeur
+   source** (D300) ; *(le scan reste hors D300 — la question pour
+   plus tard si besoin)* ;
 8. **États et interactions** — la lecture seule par nature ; masqué
    par la confidentialité ;
-9. **Décisions fondatrices** — D252, D300, D369, D461, D484, D533,
-   D542–D543 ;
+9. **Décisions fondatrices** — D252, D300, D366, D369, D461, D484,
+   D533, D542–D544 ;
 10. **Exemple de configuration** —
 
 ```yaml

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -1423,15 +1423,18 @@ page:                              # la section seule, directement (D490)
    D455) ; les droits et la confidentialité ;
 5. **Propriétés** — `label:` — les libellés par langue (D465), ou la
    référence au dictionnaire (D440) ; le socle du vocabulaire (D461 :
-   style…) ; **le mode publipostage** (D559–D560, *les cinq briques
-   en proposition*) : **les variables** `{champ}` au format de la
-   langue du document (D369) et les chemins (`{customer.address.city}`
-   — D71) ; **`if:`** — l'alinéa conditionnel (D90) ; **`style:`**
-   (D536) et les titres à quatre niveaux (D250) ; le
-   **multi-alinéas** — la lettre d'un seul bloc ; **la liste en puces
-   ou en indices** (D561) — la collection énumérée dans la lettre
-   (*en proposition :* `{overdue[bullets]}` / `{overdue[numbers]}` —
-   le `title` D465 par élément) ;
+   style…) ; **le mode publipostage : mustache + markdown**
+   (D559–D562) — **mustache** : les variables `{{champ}}` au format
+   de la langue du document (D369), les chemins
+   (`{{customer.address.city}}` — D71), **les sections**
+   `{{#overdue}}…{{/overdue}}` (l'itération des collections — la puce
+   markdown dans la section fait la liste D561) ; **markdown** : les
+   titres (`#`…`####` — D250), le gras/l'italique, les puces et les
+   indices, les tableaux ; **les limites** : aucun composant dans le
+   texte — pas de liste-composant, pas d'image (`![…]` exclu —
+   l'image reste `picture`) ; **`if:`** — l'alinéa conditionnel à
+   l'expression (D90 — mustache est sans logique) ; le champ texte de
+   l'utilisateur reste nu (D261) ;
 6. **Items** — aucun ;
 7. **Modes et déclinaisons** — au formulaire : le paragraphe en
    place ; **template** : le texte du gabarit — les mentions légales
@@ -1439,8 +1442,8 @@ page:                              # la section seule, directement (D490)
    étoffée au point gabarit / génération de documents (Q55)* ;
 8. **États et interactions** — la visibilité par les droits ; rien
    d'autre — le texte ne se clique pas ;
-9. **Décisions fondatrices** — D71, D90, D250, D369, D440, D455,
-   D461, D465, D488, D536, D559–D561 ;
+9. **Décisions fondatrices** — D71, D90, D250, D261, D369, D440,
+   D455, D461, D465, D488, D536, D559–D562 ;
 10. **Exemple de configuration** —
 
 ```yaml

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2575,8 +2575,9 @@ widgets:
    (D231) ; **les transitions conditionnelles** — « si client
    étranger → étape TVA » (D231/D90) ; **la transaction finale**
    (D232/D101 — rien ne s'écrit avant la conclusion, la relecture
-   D431 en clôture) ; **le brouillon = un niveau d'état déclaré,
-   jamais une machinerie** (D233) ;
+   D431 en clôture) ; **pas de brouillon** — « le mode draft s'efface
+   avec la possibilité de pré-exécuter une opération » (D547 ; le
+   niveau d'état déclaré D233 reste l'affaire de l'entité) ;
 6. **Items** — **les étapes : `steps:`/`step:` — « un habillage de
    `tabs[wizard]` où chaque step est en fait un tab »** (D546, le
    couple acté) : chaque étape porte sa poignée (`title:`/`icon:` —
@@ -2584,8 +2585,10 @@ widgets:
    d'un formulaire), sa condition (*en proposition :* **`if:`** — la
    transition conditionnelle D231/D90, l'étape sautée si la condition
    ne tient pas), et **son opération** — « un step peut contenir une
-   opération sur la validation » (D546 — jouée au passage, l'acte
-   D511 ; *en proposition :* `operation: <nom>`) ;
+   opération sur la validation » (D546 — *en proposition :*
+   `operation: <nom>`) : **pré-exécutée au passage** (D547 — le
+   chiffrage D511), **la transformation n'ayant lieu qu'à la
+   validation définitive du wizard** ;
 7. **Modes et déclinaisons** — **le squelette `tabs[wizard]`**
    (D504–D505) : toutes les étapes visibles, **l'avance au rythme de
    l'exploration**, « les tabs parcourus décrivent le chemin de
@@ -2596,13 +2599,14 @@ widgets:
    d'assemblage états + opérations + notifications, sans moteur BPM
    (D233) ;
 8. **États et interactions** — **l'état transitoire** jusqu'à la
-   transaction finale (D232/D101) ; l'interruption : **le brouillon
-   déclaré** (*en proposition :* `draft: <état>` — l'enregistrement
-   survit au niveau d'état déclaré D233 ; absent, la session
-   emporte tout) ;
+   transaction finale (D232/D101) — **la chaîne de pré-exécutions**
+   (D547) : rien ne se transforme avant la validation définitive ;
+   **la confirmation validée barre le retour** — le chemin navigable
+   (D505) s'arrête au dernier step confirmé (le cliquet) ;
+   l'interruption emporte le transitoire (D547 — le draft effacé) ;
 9. **Décisions fondatrices** — D90, D101, D196, D230–D233, D431,
    D438–D439, D449–D450, D455, D465, D504–D505, D511, D532, D535,
-   D546 ;
+   D546–D547 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -2610,7 +2614,6 @@ widgets:
 wizards:
   new_order:                       # le menu : sales.order[@new_order] (D439)
     title: { fr: Nouvelle commande }
-    draft: draft                   # l'interruption survit à l'état déclaré (D233)
     steps:
       - step:
           title: { fr: Client }

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2435,3 +2435,58 @@ summaries:
 # et depuis la commande : field[customer] affiche le title (D465) ;
 # le clic déploie ce résumé au-dessus de la pile (D215/D535)
 ```
+
+## `widget`
+
+1. **Nom et famille** — `widget`, une surface — `gui: widgets:
+   <nom>:` ; **associé à une entité — et par construction à un module
+   fonctionnel** (D247) ; **« défaut : n'existe pas »** (D202) ;
+2. **Rôle** — la petite surface autonome — **deux usages, une seule
+   surface** (*la lecture en proposition*) : **la carte d'un
+   enregistrement** (D492 — la liste en widgets) et **la synthèse**
+   (D202 — « compteurs, sommes/calculs, graphiques, tableaux de
+   valeurs », le drill-down) ;
+3. **Types servis** — l'entité : l'enregistrement (la carte) ou son
+   périmètre agrégé (la synthèse) ;
+4. **Contexte consommé** — l'enregistrement (la carte) ou le
+   périmètre (la synthèse) ; **la confidentialité héritée de
+   l'entité, surchargeable** (D247) ; l'utilisateur (le pool de
+   l'accueil — D204) ;
+5. **Propriétés** — `title:` (D449/D465) ; `size:` (la surimpression
+   sur la pile — D535, la grammaire D533) ; `screen:` (D450/D532) ;
+   la config de formulaire restreinte (l'esprit D201 — petit par
+   nature) ;
+6. **Items** — les sections et les feuilles (la carte — D492) ; les
+   graphiques — `chart[<nom>]` (la synthèse — D243/D540) ; l'unique
+   page, jamais d'onglets (l'écho D537) ;
+7. **Modes et déclinaisons** — **la liste en widgets** (`widget:
+   <nom>` — D492) ; **la page d'accueil** : le pool — « l'utilisateur
+   compose parmi les widgets de ses modules fonctionnels, sous sa
+   confidentialité » (D204/D247) ; le tableau de bord (D249) ;
+   **l'évaluation aux règles des champs calculés** (D248 — l'écart
+   drill-down assumé, l'alerte de périmètre) ;
+8. **États et interactions** — **le drill-down** vers une liste à
+   filtres définis (D202/D242) ; le clic sur la carte ouvre le
+   formulaire de l'enregistrement (l'écho D522) ; la confidentialité
+   masque ;
+9. **Décisions fondatrices** — D202, D204, D242–D243, D247–D249,
+   D437–D438, D449–D450, D455, D465, D492, D533, D535, D538, D540 ;
+10. **Exemple de configuration** —
+
+```yaml
+# sales/entities/order.yml, bloc gui
+widgets:
+  card:                            # la carte de l'enregistrement (D492)
+    page:
+      - sections:
+          layout: row
+          items:
+            - section: { items: [ field[number], field[state] ] }
+            - section: { items: [ field[total] ] }
+
+  monthly:                         # la synthèse (D202) — le pool de l'accueil (D204)
+    title: { fr: Le mois en cours }
+    page:
+      - chart[monthly_revenue]     # le kpi (D540)
+      - chart[revenue_by_month]    # la courbe — le drill vers la liste (D202/D242)
+```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2105,17 +2105,24 @@ charts:
    **`icons:` par seuils** — « associer éventuellement une icône :
    cas d'un feu tricolore » (D526 — la mécanique D467 dupliquée ; la
    collision avec la feuille `icons` notée, le contexte départage
-   D458 ; la liaison `icon:` à la table D495) ; `drill:` (D242) ; **pas de comparaison dans le socle** (D245 —
+   D458 ; la liaison `icon:` à la table D495) ; **`layout:`** —
+   « l'organisation se découpe en 4 » (D527) : la position du label —
+   `top` (défaut) `| left | bottom | right` (les bords D525),
+   **l'icône au bord opposé** (*la collision avec le layout des
+   sections D490 notée — les valeurs départagent, D458*) ; `drill:`
+   (D242) ; **pas de comparaison dans le socle** (D245 —
    l'évolution contre une période = un hook) ;
 6. **Items** — aucun ;
-7. **Modes et déclinaisons** — **le widget roi** (l'entité → le
-   module fonctionnel — D247), le tableau de bord (le
-   rafraîchissement D249), le formulaire possible (D243) ;
-   **template** : la valeur au format ;
+7. **Modes et déclinaisons** — **« mis en valeur avec un style
+   différent de la feuille »** (D527) : le chiffre en exergue, jamais
+   comme un champ ; **le widget roi** (l'entité → le module
+   fonctionnel — D247), le tableau de bord (le rafraîchissement
+   D249), le formulaire possible (D243) ; **template** : la valeur au
+   format ;
 8. **États et interactions** — le clic : le drill-down (D242) ou les
    valeurs du calcul (D516) ; la confidentialité masque ;
 9. **Décisions fondatrices** — D158, D242–D243, D245, D247–D249,
-   D467, D495, D512, D515–D518, D526 ;
+   D467, D495, D512, D515–D518, D526–D527 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -2130,5 +2137,6 @@ charts:
     colors: { 0: red, 50000: orange, 100000: green }   # les seuils (D467)
     icons:  { 0: red_light.svg, 50000: orange_light.svg, 100000: green_light.svg }
                                  # le feu tricolore (D526)
+    layout: left                 # le label à gauche, l'icône à droite (D527)
     drill: invoiced              # le clic : la liste (D242)
 ```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2060,7 +2060,10 @@ charts:
    proposition*) : `y:` en liste de séries —
    `{ value:, as: line | bars, axis: left | right }` — la nature et
    l'axe de chacune (défauts : la première à gauche, la seconde à
-   droite) ; **deux axes maximum** — « au-delà de 2 axes, illisible »
+   droite) ; **ou `axis: bottom | up`** — « la représentation en
+   ligne contre la représentation en colonne » (D524) : les valeurs
+   couchées, la paire homogène par construction (*la virgule
+   up/top — D504 — à harmoniser*) ; **deux axes maximum** — « au-delà de 2 axes, illisible »
    (D239) : la troisième série refusée à l'ingestion, le hook pour
    aller au-delà ;
 6. **Items** — aucun ;
@@ -2070,7 +2073,7 @@ charts:
 8. **États et interactions** — le drill-down au clic (D242) ; les
    valeurs du calcul (D516) ; la confidentialité masque ;
 9. **Décisions fondatrices** — D239–D243, D247–D249, D512,
-   D515–D518, D521 ;
+   D515–D518, D521, D524 ;
 10. **Exemple de configuration** —
 
 ```yaml

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2399,17 +2399,19 @@ forms:
 6. **Items** — la restriction du formulaire : **plusieurs sections
    possibles — « pour mêler des affichages horizontaux et
    verticaux »** (D537 — l'organisateur `sections` et ses layouts,
-   D489–D491) et les feuilles ; **l'unique page, jamais d'onglets**
-   (D201/D537) ;
+   D489–D491) et les feuilles ; **un kpi ou un chart — « à condition
+   que son affichage reste modeste »** (D538 — `chart[<nom>]` en
+   items, *la famille des adresses en proposition*) ; **l'unique
+   page, jamais d'onglets** (D201/D537) ;
 7. **Modes et déclinaisons** — l'appel depuis la référence (D215 — le
    1-1 affiche le libellé, le résumé se déploie) ; la lecture seule
    et/ou la modification mêlées (D201) ; le responsive au repli
    (D203) ;
 8. **États et interactions** — les droits décident du modifiable ; la
    fermeture rend à la surface précédente (la pile — D535) ;
-9. **Décisions fondatrices** — D186, D196, D201, D203, D215, D386,
-   D437–D438, D449–D450, D455, D461, D465, D489–D491, D532–D533,
-   D535, D537 ;
+9. **Décisions fondatrices** — D186, D196, D201, D203, D215, D243,
+   D386, D437–D438, D449–D450, D455, D461, D465, D489–D491,
+   D532–D533, D535, D537–D538 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -2425,6 +2427,7 @@ summaries:
             - section: { items: [ field[photo] ] }
             - section: { items: [ field[name], field[phone] ] }
       - field[balance]: { mode: read-only }   # le mêlé lecture/modification (D201)
+      - chart[orders_kpi]          # le kpi modeste (D538)
 
 # et depuis la commande : field[customer] affiche le title (D465) ;
 # le clic déploie ce résumé au-dessus de la pile (D215/D535)

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2235,13 +2235,24 @@ les widgets, le wizard, les templates, le dashboard du module).*
    (l'onglet par type, le modèle, le tri d'export — D445), **le
    template** (la génération — D483/D511) — *en proposition :*
    `exports: [ csv, excel[stock.xlsx], template[order_sheet] ]` ;
-   `title:` (D493) ;
-6. **Items** — aucun : la surface se déclare par ses propriétés ;
-7. **Modes et déclinaisons** — le tableau ou les widgets (D492) ; **le
-   filtrage vivant** — la liste s'auto-rafraîchit sans bouton
-   (D226–D229/D444) ; **la pagination au curseur opaque** avec les
-   indicateurs de position ; l'embarquée d'une composition ou d'une
-   association (D486) ; le responsive au repli (Q48) ;
+   **`actions:`** — la liste d'opérations (D531) : **l'opération
+   porte son icône à la déclaration, la liste la surcharge** au
+   besoin ; `title:` (D493) ;
+6. **Items** — aucun à déclarer : **l'anatomie est celle d'un
+   `pages`** (D531 — intrinsèque) ;
+7. **Modes et déclinaisons** — **« une liste est comme pages »**
+   (D531) : **le header** — le titre, les colonnes (le tabulaire ;
+   « non visibles sur les widgets, sauf pour assurer les tris »), les
+   filtres, **l'icône-menu des exports**, les icônes de l'ajout, de
+   la modification, de la suppression, **étendues aux actions à
+   icône** ; **la zone page** — le contenu du tableau ; **le
+   footer** — le sous-total ou un gabarit (`{count}` — *en
+   proposition*), **les boutons des actions sans icône** ; le tableau
+   ou les widgets (D492) ; **le filtrage vivant** — la liste
+   s'auto-rafraîchit sans bouton (D226–D229/D444) ; **la pagination
+   au curseur opaque** avec les indicateurs ; l'embarquée d'une
+   composition ou d'une association (D486) ; le responsive au repli
+   (Q48) ;
 8. **États et interactions** — **la création : le bouton compris dans
    le cadre** — le formulaire d'`add:` (D530) ; **la modification au
    double-clic** — celui d'`update:` ; la lecture seule → la
@@ -2251,7 +2262,7 @@ les widgets, le wizard, les templates, le dashboard du module).*
    sélectionnées (D446) ; les opérations en colonne à trois états
    (D444) ;
 9. **Décisions fondatrices** — D226–D229, D437–D448, D462, D466–D467,
-   D486, D492–D493, D530 ;
+   D486, D492–D493, D530–D531 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -2273,6 +2284,8 @@ lists:
     add: quick_entry               # le formulaire du bouton + (D530)
     update: default                # celui du double-clic — le défaut sinon (D438)
     exports: [ csv, excel[orders.xlsx], template[order_sheet] ]   # (D530)
+    actions: [ invoice, cancel ]   # les opérations — l'icône au header, sinon
+                                   # le bouton du pied (D531)
 
   cards:                           # le second visage (D492)
     widget: card                   # chaque enregistrement rendu par son widget

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2060,10 +2060,10 @@ charts:
    proposition*) : `y:` en liste de séries —
    `{ value:, as: line | bars, axis: left | right }` — la nature et
    l'axe de chacune (défauts : la première à gauche, la seconde à
-   droite) ; **ou `axis: bottom | up`** — « la représentation en
-   ligne contre la représentation en colonne » (D524) : les valeurs
-   couchées, la paire homogène par construction (*la virgule
-   up/top — D504 — à harmoniser*) ; **deux axes maximum** — « au-delà de 2 axes, illisible »
+   droite) ; **ou `axis: bottom | top`** — « la représentation en
+   ligne contre la représentation en colonne » (D524, harmonisé
+   D525) : les valeurs couchées, la paire homogène par construction —
+   les bords d'un seul vocabulaire (D504) ; **deux axes maximum** — « au-delà de 2 axes, illisible »
    (D239) : la troisième série refusée à l'ingestion, le hook pour
    aller au-delà ;
 6. **Items** — aucun ;
@@ -2073,7 +2073,7 @@ charts:
 8. **États et interactions** — le drill-down au clic (D242) ; les
    valeurs du calcul (D516) ; la confidentialité masque ;
 9. **Décisions fondatrices** — D239–D243, D247–D249, D512,
-   D515–D518, D521, D524 ;
+   D515–D518, D521, D524–D525 ;
 10. **Exemple de configuration** —
 
 ```yaml

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -1573,10 +1573,13 @@ gui:
    proposition*) ;
 7. **Modes et déclinaisons** — la barre des poignées + le volet
    courant — en haut, en bas, latérale (D504) ; **le mode wizard** :
-   les étapes toutes visibles, l'avance au rythme de l'exploration
-   (la parenté avec la surface `wizard` D230–D233) — **« les tabs
-   parcourus décrivent le chemin de traitement »** : le clic sur une
-   phase explorée y ramène, l'avance reste gardée (D505) ; l'entête, le
+   les étapes toutes visibles, l'avance au rythme de l'exploration —
+   **« les tabs parcourus décrivent le chemin de traitement »** : le
+   clic sur une phase explorée y ramène, l'avance reste gardée
+   (D505) ; **`tabs[wizard]` est le wizard même** (D551) : l'`if:` et
+   l'`operation:` d'étape, la chaîne de pré-exécutions, la
+   transformation finale, le cliquet, le `breadcrumb:`, les
+   graphiques — tout D546–D550 s'y porte ; l'entête, le
    corps et le pied acceptent les onglets (D450) ; **tactile** : le
    swipe bascule d'un onglet à l'autre (l'esprit D503) ;
    **template** : les onglets rendus à la suite (*en proposition —
@@ -2557,7 +2560,10 @@ widgets:
 
 1. **Nom et famille** — `wizard`, une surface — `gui: wizards:
    <nom>:` ; le menu l'adresse (`[@wizard]` — D439) ; la première
-   déclarée = le défaut (D438) ;
+   déclarée = le défaut (D438) ; **le même objet que `tabs[wizard]`**
+   (D551 — l'écho D486 : « un seul list ») — tout ce qui suit vaut
+   des deux côtés, seule change la porte d'entrée (le menu ou
+   l'emboîtement) ;
 2. **Rôle** — **le parcours guidé : « mono-utilisateur, une
    session »** (D230) — les étapes s'enchaînent, la transaction
    conclut ; **la démarche au sens large** (D546) : créer un

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -1994,3 +1994,50 @@ charts:
     x: party
     y: count()
 ```
+
+## `chart.scatter`
+
+1. **Nom et famille** — `chart.scatter`, un graphique de la famille
+   pointée — le nuage de points, l'ajout de l'auteur (D512) ;
+2. **Rôle** — **« représenter une concentration ou une dispersion
+   d'une certaine valeur »** — et **« aider à catégoriser des
+   éléments »** (D522) : la matrice de décision ;
+3. **Types servis** — l'assise (D517–D518) ; **le grain diffère** :
+   un point par **enregistrement** — `x:` et `y:` deux champs
+   numériques **nus** (sans agrégat), là où courbe et barres
+   agrègent (D522) ;
+4. **Contexte consommé** — le socle des `chart.*` (la confidentialité
+   D247, les droits) ; **le visage de l'enregistrement** (D386) ;
+5. **Propriétés** — **le socle commun** (D515–D518, D521 — `display:`
+   compris) ; **les écarts propres** (D522, *écritures en
+   proposition*) : **`thresholds:`** dans la forme riche de l'axe —
+   la liste croissante de seuils, « qui ne se chevauchent pas » par
+   construction — les bandes ; **`zones:`** — la zone au croisement
+   des bandes (`x: 0..50` aux bornes D366, `title:` D493, `color:`
+   D496) : le MoSCoW à deux critères, l'effort/bénéfice ;
+6. **Items** — aucun ;
+7. **Modes et déclinaisons** — réutilisable (D243/D249) ; template :
+   l'image (D257) ; **le survol** : le visage de l'enregistrement
+   (D386) ; le tableau des valeurs (`display:` — D521) ;
+8. **États et interactions** — **le clic sur un point : le
+   formulaire de l'enregistrement** ; **le clic sur une zone : la
+   liste de ses éléments** (l'écho D519) ; la confidentialité
+   masque ;
+9. **Décisions fondatrices** — D239–D243, D247–D249, D386, D512,
+   D515–D518, D521–D522 ;
+10. **Exemple de configuration** —
+
+```yaml
+# projects/entities/action.yml, bloc gui — la matrice effort/bénéfice (D522)
+charts:
+  priorities:
+    component: chart.scatter
+    x: { value: effort,  min: 0, max: 100, thresholds: [50] }
+    y: { value: benefit, min: 0, max: 100, thresholds: [50] }
+    zones:
+      - { x: 0..50,   y: 50..100, title: { fr: Gains rapides }, color: green }
+      - { x: 50..100, y: 50..100, title: { fr: Grands projets }, color: orange }
+      - { x: 0..50,   y: 0..50,   title: { fr: Tâches de fond }, color: gray }
+      - { x: 50..100, y: 0..50,   title: { fr: À éviter },      color: red }
+    labels: true                  # le visage au survol (D386)
+```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -1423,7 +1423,12 @@ page:                              # la section seule, directement (D490)
    D455) ; les droits et la confidentialité ;
 5. **Propriétés** — `label:` — les libellés par langue (D465), ou la
    référence au dictionnaire (D440) ; le socle du vocabulaire (D461 :
-   style…) ;
+   style…) ; **le mode publipostage** (D559–D560, *les cinq briques
+   en proposition*) : **les variables** `{champ}` au format de la
+   langue du document (D369) et les chemins (`{customer.address.city}`
+   — D71) ; **`if:`** — l'alinéa conditionnel (D90) ; **`style:`**
+   (D536) et les titres à quatre niveaux (D250) ; le
+   **multi-alinéas** — la lettre d'un seul bloc ;
 6. **Items** — aucun ;
 7. **Modes et déclinaisons** — au formulaire : le paragraphe en
    place ; **template** : le texte du gabarit — les mentions légales
@@ -1431,7 +1436,8 @@ page:                              # la section seule, directement (D490)
    étoffée au point gabarit / génération de documents (Q55)* ;
 8. **États et interactions** — la visibilité par les droits ; rien
    d'autre — le texte ne se clique pas ;
-9. **Décisions fondatrices** — D440, D455, D461, D465, D488, D559 ;
+9. **Décisions fondatrices** — D71, D90, D250, D369, D440, D455,
+   D461, D465, D488, D536, D559–D560 ;
 10. **Exemple de configuration** —
 
 ```yaml

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2686,7 +2686,9 @@ wizards:
    sien** — la page d'accueil = un dashboard personnel, pioché dans
    le pool des widgets de ses modules, sous sa confidentialité
    (D204/D247/D191) — **le cas limite du squelette entièrement
-   libre** (D555) ; le responsive au repli (D203) ;
+   libre** (D555) ; **« une page d'accueil fait référence à un
+   dashboard selon le module activé »** (D557) — le changement de
+   module change le tableau de bord ; le responsive au repli (D203) ;
 8. **États et interactions** — **le drill-down** de chaque widget
    (D202/D242) ; la confidentialité masque widget par widget (D247) ;
    le rafraîchissement vit selon son mode (D249) ; **l'emplacement
@@ -2694,7 +2696,7 @@ wizards:
    libération (D556) ;
 9. **Décisions fondatrices** — D191, D202–D204, D242–D243,
    D247–D249, D434, D438–D439, D449–D450, D455, D461, D465, D532,
-   D535, D540, D554–D556 ;
+   D535, D540, D554–D557 ;
 10. **Exemple de configuration** —
 
 ```yaml

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2570,17 +2570,23 @@ widgets:
    dans son agrégat (D101) ;
 4. **Contexte consommé** — l'enregistrement transitoire, l'origine de
    l'appel, l'utilisateur (D455) ; les droits (D196) ;
-5. **Propriétés** — `title:` (D449/D465) ; `size:` (la pile — D535) ;
-   `screen:` (D450/D532) ; **les étapes = des surfaces déclarées**
+5. **Propriétés** — `title:` (D449/D465) ; **`size:` obligatoire** —
+   « un wizard doit avoir une dimension », **surchargeable au nœud
+   incluant** quand il s'emboîte dans un formulaire (D548/D455, le
+   plus proche l'emporte D461 ; la pile D535, la grammaire D533) ;
+   **le fil d'Ariane en haut ou en bas** (D548 — *en proposition :*
+   `mode: top` (défaut) `| bottom`, les bords D525) ; `screen:`
+   (D450/D532) ; **les étapes = des surfaces déclarées**
    (D231) ; **les transitions conditionnelles** — « si client
    étranger → étape TVA » (D231/D90) ; **la transaction finale**
    (D232/D101 — rien ne s'écrit avant la conclusion, la relecture
    D431 en clôture) ; **pas de brouillon** — « le mode draft s'efface
    avec la possibilité de pré-exécuter une opération » (D547 ; le
    niveau d'état déclaré D233 reste l'affaire de l'entité) ;
-6. **Items** — **les étapes : `steps:`/`step:` — « un habillage de
-   `tabs[wizard]` où chaque step est en fait un tab »** (D546, le
-   couple acté) : chaque étape porte sa poignée (`title:`/`icon:` —
+6. **Items** — **un `header` et un `footer` optionnels** (D548 —
+   l'écho de `pages` D507 : toujours visibles autour des steps) ;
+   **les étapes : `steps:`/`step:` — « un habillage de `tabs[wizard]`
+   où chaque step est en fait un tab »** (D546, le couple acté) : chaque étape porte sa poignée (`title:`/`icon:` —
    le chemin D505), ses items (les sections, les feuilles — la page
    d'un formulaire), sa condition (*en proposition :* **`if:`** — la
    transition conditionnelle D231/D90, l'étape sautée si la condition
@@ -2605,8 +2611,8 @@ widgets:
    (D505) s'arrête au dernier step confirmé (le cliquet) ;
    l'interruption emporte le transitoire (D547 — le draft effacé) ;
 9. **Décisions fondatrices** — D90, D101, D196, D230–D233, D431,
-   D438–D439, D449–D450, D455, D465, D504–D505, D511, D532, D535,
-   D546–D547 ;
+   D438–D439, D449–D450, D455, D465, D504–D505, D507, D511, D525,
+   D532–D533, D535, D546–D548 ;
 10. **Exemple de configuration** —
 
 ```yaml

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -1889,3 +1889,49 @@ charts:
     colors: { serie: blue }      # la mécanique D467 — le dégradé possible
     labels: true                 # la valeur au format du champ (D516)
 ```
+
+## `chart.bars`
+
+1. **Nom et famille** — `chart.bars`, un graphique de la famille
+   pointée (D512) — les barres ;
+2. **Rôle** — la comparaison des quantités par catégorie : la barre
+   qui mesure ;
+3. **Types servis** — l'assise (D517–D518 : l'entité porteuse ou
+   `on:`), les axes aux champs — le découpage **par valeurs** y est
+   roi (les catégories — D240), les plages et la temporalité
+   possibles ;
+4. **Contexte consommé** — le socle des `chart.*` : la confidentialité
+   héritée surchargeable (D247), les droits ;
+5. **Propriétés** — **le socle commun** (D515–D518) : `on:`, `x:`,
+   `y:` (la forme riche — et la liste : plusieurs séries), `filter:`,
+   `drill:`, `colors:`, `labels:`, `title:` ; **les écarts propres**
+   (*en proposition*) : **`mode: vertical | horizontal`** (défaut
+   vertical — le crochet en raccourci : `chart.bars[horizontal]`,
+   D478) ; **`stacked:`** — les séries empilées (`true`), côte à côte
+   sinon (défaut) ;
+6. **Items** — aucun ;
+7. **Modes et déclinaisons** — réutilisable : le widget, le
+   formulaire, le tableau de bord (D243/D249) ; **template** :
+   l'image (D257) ; tactile : la barre touchée montre sa valeur ;
+8. **États et interactions** — le drill-down au clic (D242) ; le clic
+   sur une barre : les valeurs du calcul (D516) ; la confidentialité
+   masque ;
+9. **Décisions fondatrices** — D239–D243, D247–D249, D512,
+   D515–D518 ;
+10. **Exemple de configuration** —
+
+```yaml
+# sales/entities/order.yml, bloc gui
+charts:
+  revenue_by_seller:
+    component: chart.bars[horizontal]   # ≡ mode: horizontal (D478)
+    x: seller                    # le découpage par valeurs (D240)
+    y: [ sum(total), sum(margin) ]      # deux séries côte à côte
+    labels: true
+
+  stock_by_site:
+    component: chart.bars
+    stacked: true                # les séries empilées (proposition)
+    x: site
+    y: [ sum(reserved), sum(available) ]
+```

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -1559,42 +1559,35 @@ gui:
 4. **Contexte consommé** — le contexte transmis tel quel aux items
    (D455) ; les droits et la confidentialité — **l'onglet masqué
    disparaît de la barre** ;
-5. **Propriétés** — **`mode:`** — les visages de la barre (D504) :
-   `top` (Windows — le défaut), `bottom` (Excel), `left`/`right` (la
-   latérale), **`wizard`** (« voir toutes les étapes mais ne pas
-   prendre d'avance tant que l'onglet précédent n'a pas été exploré »
-   — l'écho du cliquet D354) ; le crochet en raccourci :
-   `tabs[bottom]`, `tabs[wizard]` (*l'écriture en proposition —
-   D478*) ; `size:` — l'espace du tout (l'écho D503/D484) ; **la
+5. **Propriétés** — **`mode:`** — les visages de la barre (D504,
+   amendé D552) : `top` (Windows — le défaut), `bottom` (Excel),
+   `left`/`right` (la latérale) — **le mode wizard a quitté tabs**
+   (D552 : la séparation) ; le crochet en raccourci : `tabs[bottom]`
+   (*l'écriture en proposition — D478*) ; `size:` — l'espace du tout (l'écho D503/D484) ; **la
    dimension unique des volets** — « pour chaque tab, toujours la même
    dimension » (D506 — aucun `width`/`height` par volet, le contraste
    avec D502) ; le socle du vocabulaire (D461) ;
 6. **Items** — **des `tab`, rien d'autre** (*le miroir de D489 — en
    proposition*) ;
 7. **Modes et déclinaisons** — la barre des poignées + le volet
-   courant — en haut, en bas, latérale (D504) ; **le mode wizard** :
-   les étapes toutes visibles, l'avance au rythme de l'exploration —
-   **« les tabs parcourus décrivent le chemin de traitement »** : le
-   clic sur une phase explorée y ramène, l'avance reste gardée
-   (D505) ; **`tabs[wizard]` est le wizard même** (D551) : l'`if:` et
-   l'`operation:` d'étape, la chaîne de pré-exécutions, la
-   transformation finale, le cliquet, le `breadcrumb:`, les
-   graphiques — tout D546–D550 s'y porte ; l'entête, le
-   corps et le pied acceptent les onglets (D450) ; **tactile** : le
-   swipe bascule d'un onglet à l'autre (l'esprit D503) ;
-   **template** : les onglets rendus à la suite (*en proposition —
-   rien ne bascule sur le papier*) ;
+   courant — en haut, en bas, latérale (D504/D552) ; **la parenté
+   visuelle avec le `wizard` est assumée, les objets restent
+   distincts** (D552 — la navigation libre ici, le parcours contraint
+   là-bas) ; l'entête, le corps et le pied acceptent les onglets
+   (D450) ; **tactile** : le swipe bascule d'un onglet à l'autre
+   (l'esprit D503) ; **template** : les onglets rendus à la suite
+   (*en proposition — rien ne bascule sur le papier*) ;
 8. **États et interactions** — la bascule au clic ou au swipe ;
    l'onglet masqué par les droits disparaît ; le fil peut prendre un
    onglet (D485) ;
 9. **Décisions fondatrices** — D449–D451, D455–D456, D461, D485,
-   D487, D489 (le patron), D503–D506 ;
+   D487, D489 (le patron), D503–D506, D552 ;
 10. **Exemple de configuration** — *(le couple vit ensemble)* —
 
 ```yaml
 page:
   - tabs:
-      mode: wizard               # les étapes — l'avance à l'exploration (D504)
+      mode: bottom               # la barre en bas — le style Excel (D504)
       items:
         - tab:
             title: { fr: Général }
@@ -1774,9 +1767,14 @@ forms:
    d'état du graphe (D425–D427, l'opération du catalogue par défaut —
    D433) ;
 4. **Contexte consommé** — l'opération : sa garde (`if` — D430), ses
-   droits (D196), son `validate:` (D431) ; l'enregistrement ou la
-   sélection (l'opération de masse — D446) ; **la pré-exécution**
-   (D511) — les modifications à venir, chiffrées ;
+   droits (D196), son `validate:` (D431) ; **la pile des contextes**
+   (D553) — « l'ensemble des contextes qui se sont empilés jusqu'à
+   l'usage de l'opération » : le périmètre de la liste,
+   l'enregistrement du formulaire, le transitoire du wizard —
+   l'origine de l'appel (D455) est la pile entière ;
+   l'enregistrement ou la sélection (l'opération de masse — D446) ;
+   **la pré-exécution** (D511) — les modifications à venir,
+   chiffrées ;
 5. **Propriétés** — la surcharge de la présentation : `label:`,
    `icon:`, `style:` (le verbe du catalogue en défaut) ;
    **`validate:`** — `true` (défaut — la relecture D431) ou **le
@@ -1800,7 +1798,7 @@ forms:
    seule + confirmer/annuler, jamais de popup D196) ; l'exécution
    `synchronous`/`asynchronous`/`await` (D436) ;
 9. **Décisions fondatrices** — D196, D425–D433, D436, D439, D444,
-   D446, D456, D460, D462, D504–D505, D511 ;
+   D446, D456, D460, D462, D504–D505, D511, D553 ;
 10. **Exemple de configuration** —
 
 ```yaml
@@ -2560,10 +2558,10 @@ widgets:
 
 1. **Nom et famille** — `wizard`, une surface — `gui: wizards:
    <nom>:` ; le menu l'adresse (`[@wizard]` — D439) ; la première
-   déclarée = le défaut (D438) ; **le même objet que `tabs[wizard]`**
-   (D551 — l'écho D486 : « un seul list ») — tout ce qui suit vaut
-   des deux côtés, seule change la porte d'entrée (le menu ou
-   l'emboîtement) ;
+   déclarée = le défaut (D438) ; **séparé de `tabs`**
+   (D552 — « je valide la séparation ») : deux objets, une parenté
+   visuelle assumée — le vocabulaire du parcours (steps/step) tout
+   entier chez lui ;
 2. **Rôle** — **le parcours guidé : « mono-utilisateur, une
    session »** (D230) — les étapes s'enchaînent, la transaction
    conclut ; **la démarche au sens large** (D546) : créer un
@@ -2592,8 +2590,8 @@ widgets:
    niveau d'état déclaré D233 reste l'affaire de l'entité) ;
 6. **Items** — **un `header` et un `footer` optionnels** (D548 —
    l'écho de `pages` D507 : toujours visibles autour des steps) ;
-   **les étapes : `steps:`/`step:` — « un habillage de `tabs[wizard]`
-   où chaque step est en fait un tab »** (D546, le couple acté) : chaque étape porte sa poignée (`title:`/`icon:` —
+   **les étapes : `steps:`/`step:`** (D546, le couple acté ; la
+   séparation D552 — le step n'est plus un tab) : chaque étape porte sa poignée (`title:`/`icon:` —
    le chemin D505), ses items (les sections, les feuilles — la page
    d'un formulaire — **et les graphiques : `chart[<nom>]`, kpi,
    pivot, « l'aide à la décision »**, D550), sa condition (*en proposition :* **`if:`** — la
@@ -2603,10 +2601,11 @@ widgets:
    `operation: <nom>`) : **pré-exécutée au passage** (D547 — le
    chiffrage D511), **la transformation n'ayant lieu qu'à la
    validation définitive du wizard** ;
-7. **Modes et déclinaisons** — **le squelette `tabs[wizard]`**
-   (D504–D505) : toutes les étapes visibles, **l'avance au rythme de
-   l'exploration**, « les tabs parcourus décrivent le chemin de
-   traitement » — le retour libre d'un clic ; **le passage d'étape =
+7. **Modes et déclinaisons** — **le stepper** : toutes les étapes
+   visibles, **l'avance au rythme de l'exploration**, « le chemin de
+   traitement » navigable — le retour libre d'un clic (D505 —
+   désormais l'affaire du wizard seul ; la parenté visuelle avec les
+   onglets assumée, D552) ; **le passage d'étape =
    un acte** (D511) ; emboîtable — « rien n'empêche un formulaire
    qui inclut un wizard dans une page » (D455) ; le circuit de
    validation multi-acteurs reste **hors wizard** — le patron
@@ -2619,8 +2618,8 @@ widgets:
    (D505) s'arrête au dernier step confirmé (le cliquet) ;
    l'interruption emporte le transitoire (D547 — le draft effacé) ;
 9. **Décisions fondatrices** — D90, D101, D196, D230–D233, D431,
-   D438–D439, D449–D450, D455, D465, D504–D505, D507, D511, D525,
-   D532–D533, D535, D540, D546–D550 ;
+   D438–D439, D449–D450, D455, D465, D505, D507, D511, D525,
+   D532–D533, D535, D540, D546–D550, D552 ;
 10. **Exemple de configuration** —
 
 ```yaml

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -2194,3 +2194,79 @@ charts:
     filter: state = "invoiced"
     title: { fr: CA par commercial et par mois }
 ```
+
+# Les surfaces
+
+*Le fil conducteur de la passe : `sales.order` — les surfaces
+construites dans l'ordre d'usage (la liste, le formulaire, le résumé,
+les widgets, le wizard, les templates, le dashboard du module).*
+
+## `list` (la surface)
+
+1. **Nom et famille** — `list`, une surface — **le même composant que
+   la feuille** (D486 : « un seul list ») ; ici son visage déclaré :
+   `gui: lists: <nom>:` — **la première déclarée est la surface par
+   défaut** (D438), le menu l'adresse (`sales.order[pending]` —
+   D439) ;
+2. **Rôle** — **la porte d'entrée de l'entité** : les enregistrements
+   en tableau ou en widgets, la recherche, le tri, les opérations ;
+3. **Types servis** — l'entité (ses champs en colonnes) ; **les deux
+   visages exclusifs** (D492) : le tableau (`columns:`) ou la liste
+   de widgets (`widget:`) ;
+4. **Contexte consommé** — la confidentialité (les colonnes non
+   visibles et non triables), les droits d'action (D196), le module ;
+5. **Propriétés** — **`columns:`** — l'ordre d'affichage, les noms
+   nus (le champ l'emporte sur l'opération homonyme — D462) ; par
+   colonne : le style, l'alignement, la dimension (D442 — **le type
+   prime le format** : l'amount à droite avec devise, le toggle
+   centré, le multi-lignes justifié — D443/D448), la colonne fantôme
+   (`visible: false`), le fond gradué (`background:` — D466), les
+   couleurs (`colors:` — D467), l'aperçu du fil (`preview:` — D393) ;
+   **`widget:`** (D492) ; `filter:` (l'expression D90) ; `sort:` (par
+   colonne, à cascades, les signes — D441) ; `searchable:` (les
+   champs ou les noms mutualisés — défaut : tous) ; `editable:`
+   (**défaut : tout readonly** — D441) ; `selection: 1 | 1..`
+   (D445–D446) ; `sizable: none | auto | manual | auto+manual`
+   (D447) ; **l'export** CSV (un fichier par type de composant) /
+   Excel (un onglet par type, le modèle, le tri d'export — D445) ;
+   `title:` (D493) ;
+6. **Items** — aucun : la surface se déclare par ses propriétés ;
+7. **Modes et déclinaisons** — le tableau ou les widgets (D492) ; **le
+   filtrage vivant** — la liste s'auto-rafraîchit sans bouton
+   (D226–D229/D444) ; **la pagination au curseur opaque** avec les
+   indicateurs de position ; l'embarquée d'une composition ou d'une
+   association (D486) ; le responsive au repli (Q48) ;
+8. **États et interactions** — **la création : le bouton compris dans
+   le cadre** ; **la modification au double-clic** ; la lecture seule
+   → la consultation ; **la suppression** : une ligne = le formulaire
+   en lecture seule + la confirmation, plusieurs = le décompte
+   confirmé (D446) ; **l'opération de masse** sur les lignes
+   sélectionnées (D446) ; les opérations en colonne à trois états
+   (D444) ;
+9. **Décisions fondatrices** — D226–D229, D437–D448, D462, D466–D467,
+   D486, D492–D493 ;
+10. **Exemple de configuration** —
+
+```yaml
+# sales/entities/order.yml, bloc gui (D437)
+lists:
+  pending:                        # la première déclarée = le défaut (D438)
+    title: { fr: Commandes en cours }
+    columns:
+      - number
+      - customer
+      - total: { background: progress }   # le fond gradué (D466)
+      - discussion: { preview: 3 }        # le fil au survol (D393)
+      - invoice                    # l'opération — l'icône à 3 états (D444/D462)
+    filter: state in [draft, confirmed]
+    sort: { date: -, number: + }   # les cascades (D441)
+    editable: [notes]              # le reste readonly (D441)
+    selection: 1..                 # la multi-sélection (D446)
+    sizable: auto+manual           # (D447)
+
+  cards:                           # le second visage (D492)
+    widget: card                   # chaque enregistrement rendu par son widget
+    filter: state in [draft, confirmed]
+
+# et le menu l'adresse (D439) : sales.order[pending]
+```

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -636,6 +636,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D555 | **Le squelette de dashboard** (précise D554) : « le technicien décrit un ou plusieurs squelettes — avec des widgets contraints et des widgets libres » ; l'accueil composé = le squelette entièrement libre. | L'item `free` (répétable) en proposition. Voir §3.2c. |
 | D556 | **L'emplacement `_` et l'icône du choix** (amende D555) : « un widget interchangeable doit faire apparaître un icône qui permette de choisir un widget disponible selon son propre catalogue ou par sa libération » ; « "_" me parle plus que "free" — free pouvant être lui-même un nom de widget ». | L'item `_` acté ; la collision évitée par construction. Voir §3.2c. |
 | D557 | **L'accueil au module actif** : « une page d'accueil fait référence à un dashboard selon le module activé » — le module actif fournit son tableau de bord. | Complète D554–D556. Voir §3.2c. |
+| D558 | **La homepage aux trois pointes** (amende D557) : « la limiter à un dashboard m'embête — la homepage doit pouvoir pointer une liste, un dashboard ou une page vide ». | La lettre de D204 retrouvée ; la composition aux emplacements `_` (D555–D556). Voir §3.2c. |
 
 ---
 
@@ -4198,6 +4199,14 @@ référence à un dashboard selon le module activé. »** L'accueil n'est
 pas un tableau figé : **le module actif fournit son dashboard** — en
 changeant de module, l'utilisateur change de tableau de bord (le
 squelette du technicien, ses emplacements `_` composés — D554–D556).
+
+**La homepage aux trois pointes (D558 — amende D557).** **« J'hésite
+sur la homepage : la limiter à un dashboard m'embête. La homepage
+doit pouvoir pointer une liste, un dashboard ou une page vide. »**
+L'accueil pointe : **une liste** (l'entrée du menu — la lettre de
+D204 retrouvée), **un dashboard** (celui du module activé — D557), ou
+**la page vide** (D191). La composition personnelle vit désormais aux
+emplacements `_` des squelettes (D555–D556).
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11389,3 +11398,7 @@ avant la synthèse Q16).
 - **2026-08-14 (suite 68)** — **L'accueil au module actif (D557)** :
   « une page d'accueil fait référence à un dashboard selon le module
   activé » — le changement de module change le tableau de bord.
+- **2026-08-14 (suite 69)** — **La homepage aux trois pointes
+  (D558)** : « la limiter à un dashboard m'embête » — la liste, le
+  dashboard (du module actif — D557) ou la page vide ; la lettre de
+  D204 retrouvée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -642,6 +642,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D561 | **La sixième brique** (complète D560) : « l'affichage d'une liste sous forme de bullet points ou d'indices » — la collection dans la lettre. | `{overdue[bullets]}` / `{overdue[numbers]}` en proposition (le crochet ; le `title` D465 par élément). Voir §3.2c. |
 | D562 | **Mustache + markdown au paragraph** (remplace les écritures D560–D561) : « la combinaison doit couvrir les différents cas ; des limites portant sur les composants (pas de liste, pas d'image…) » — mustache (variables, chemins, sections-itérations), markdown (titres, gras, puces, tableaux) ; `![…]` exclu, l'`if:` d'expression demeure (D90), le champ texte utilisateur reste nu (D261). | Deux standards, zéro syntaxe maison. Voir §3.2c. |
 | D563 | **Le comportement d'`url`** (les cinq points validés) : le lien en lecture — le clic ouvre dans un nouvel onglet, l'icône du lien externe en post-zone (D271/D391) ; l'icône demeure en saisie ; l'ellipse en cellule ; le lien actif au template, la valeur nue en Excel/CSV ; l'aperçu de la cible = un hook (D263). | La synthèse complétée (la ligne url séparée). Voir §3.2c. |
+| D564 | **Les quatre destinations du template** : « générer un document Word, PDF, Excel ou un mail — le template porte une propriété `format` qui précise le format de destination ». | `format: pdf \| word \| excel \| mail` (défaut pdf en proposition) ; le mail = le publipostage D562, l'Excel = le modèle D445. Voir §3.2c. |
 
 ---
 
@@ -4274,6 +4275,15 @@ clic ouvre, le double-clic édite (D446) ; **(4) le template** — le
 texte et le lien actif ; Excel/CSV — la valeur nue, ré-importable ;
 **(5) pas de prévisualisation au socle** — l'aperçu de la cible = un
 hook (la ligne D263).
+
+**Les quatre destinations du template (D564).** **« Le template est
+utilisé pour générer un document Word, PDF, Excel ou un mail. Le
+template porte une propriété `format` qui précise le format de
+destination. »** Le gabarit s'ouvre au-delà du PDF (D212/D250 — qui
+reste le défaut naturel, *en proposition*) : **`format: pdf | word |
+excel | mail`**. Le mail rejoint le publipostage (D562) — la lettre
+mustache+markdown devient le corps du message ; l'Excel rejoint le
+modèle des exports (D445).
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11503,6 +11513,11 @@ avant la synthèse Q16).
 - **2026-08-14 (suite 77)** — **La PR #25 créée** (« Q16 domaine 4 —
   les actes, les graphiques, les surfaces : le catalogue au complet,
   D511–D563 » — 75 commits, 2 fichiers) vers develop.
+- **2026-08-14 (suite 78)** — **Les quatre destinations du template
+  (D564)** : Word, PDF, Excel ou un mail — format: précise la
+  destination (défaut pdf en proposition) ; le mail rejoint le
+  publipostage (D562). La fiche complétée — le commit rejoint la PR
+  #25 ouverte.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -609,6 +609,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D528 | **Le tri du croisé sur la valeur** : « visualiser les plus gros CA » — les lignes par la valeur agrégée, chaque niveau du groupement par son sous-total ; le défaut = l'ordre naturel du champ. | `sort: -value` en proposition (le signe D441). Voir §3.2c. |
 | D529 | **Le tri aux trois clés** (élargit D528) : « le tri peut s'appuyer sur les rows, les columns ou la value » — les signes et cascades D441 (`sort: { seller: -value, date: + }`). | Voir §3.2c. |
 | D530 | **Les appels du geste et les exports** : « add, update or delete pour préciser le formulaire/widget à appeler » (les défauts : le formulaire par défaut D438, les gestes D446) ; « exports: permet de préciser les différents exports ou générations de documents ». | `exports: [ csv, excel[modèle], template[gabarit] ]` en proposition. Voir §3.2c. |
+| D531 | **Les actions et l'anatomie de la liste** : `actions:` (l'opération porte son icône, surchargeable) ; « une liste est comme pages » — le header (titre, colonnes, filtres, l'icône-menu des exports, les icônes add/update/delete + actions à icône), la zone page (le tableau), le footer (le sous-total ou un gabarit, les boutons des actions sans icône). | L'icône trie : header ; sans icône : bouton du pied. `{count}` au gabarit en proposition. Voir §3.2c. |
 
 ---
 
@@ -3883,6 +3884,28 @@ documents** (l'effet document, le template — D483/D511). *(L'écriture
 en proposition : `exports: [ csv, excel[stock.xlsx],
 template[order_sheet] ]` — le crochet portant le modèle ou le
 gabarit.)*
+
+**Les actions et l'anatomie de la liste (D531).** **« J'ajoute
+`actions:` avec une liste d'opérations. Dans la définition d'une
+opération, nous associons un icône que nous pouvons surcharger dans la
+liste. »** — l'opération porte son icône à la déclaration (D432
+enrichi), la liste peut la surcharger. Et l'anatomie : **« une liste
+est comme pages »** (D507/D509) :
+
+- **le header** — le titre, **les colonnes** (l'affichage tabulaire —
+  « non visibles sur les widgets, sauf pour assurer les tris »), les
+  filtres de la liste, **une icône servant d'entrée de menu pour les
+  exports**, les icônes de l'ajout, de la modification, de la
+  suppression — **« la zone des icônes est étendue aux actions ayant
+  un icon »** ;
+- **la zone page** — le contenu du tableau ;
+- **le footer** — « éventuellement un sous-total ou un gabarit
+  (nombre de lignes, commentaire…) et **des boutons pour les actions
+  sans icône** ».
+
+La répartition est réglée d'elle-même : l'action à icône monte au
+header, l'action sans icône devient bouton du pied. *(En proposition :
+le gabarit du pied aux variables — `{count}` le nombre de lignes.)*
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10917,3 +10940,9 @@ avant la synthèse Q16).
   appelé (le défaut D438) ; exports: précise les exports et les
   générations de documents (le crochet au modèle/gabarit en
   proposition). La fiche complétée.
+- **2026-08-14 (suite 34)** — **Les actions et l'anatomie (D531)** :
+  actions: (l'icône à l'opération, surchargeable) ; « une liste est
+  comme pages » — header (titre/colonnes/filtres/icône-exports/icônes
+  des gestes et actions), la zone page (le tableau), footer
+  (sous-total ou gabarit + les boutons des actions sans icône). La
+  fiche restructurée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -593,6 +593,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D512 | **La famille `chart.*`** actée (l'écho des pickers, la note D470) : `chart.line`, `chart.bars`, `chart.pie`, `chart.combo` — et « j'ajouterais également **le nuage de points** » : `chart.scatter` ; `kpi` et `pivot` à part, la jauge restant la feuille `gauge`. | Le hook étend (`chart.radar`…) — D239. Voir §3.2c. |
 | D513 | **La carte des collections** : « le composant doit pouvoir s'adapter pour une coordonnée ou une liste de coordonnées dont des lignes sont possibles ou pas » — les marqueurs multiples, le tracé dans l'ordre de la collection. | Rien n'était consigné (vérifié) ; `lines: true \| false` en proposition (défaut false). Voir §3.2c. |
 | D514 | **La frontière de la route** (complète D513) : les lieux d'un produit (sans relier) / le parcours d'un commercial (relié) ; le socle relie au trait droit — **« le tracé de la route, je préfère le laisser aux hooks »** (les abonnements aux outils annexes). | Le patron du géocodage D294 — candidats open source auto-hébergeables : OSRM, Valhalla (Q7). Voir §3.2c. |
+| D515 | **Les réglages d'affichage du graphique** : « paramétrer les échelles, les début et fin d'axe et quelques éléments d'affichage (vignettes, couleurs, dégradé…) ». | En proposition : la forme riche des axes `{ value:, min:, max:, scale: }` (l'écho D494), `colors:` (D467, le dégradé), `points:` (les vignettes — le visage au nuage D386). Voir §3.2c. |
 
 ---
 
@@ -3701,6 +3702,18 @@ la route = un hook/connecteur** — le patron exact du géocodage
 (D294) : les services payants existent (Google, Mapbox), et des
 candidats open source auto-hébergeables aussi (**OSRM**, **Valhalla**
 — sur les données OpenStreetMap) ; le choix à re-vérifier en Q7.
+
+**Les réglages d'affichage du graphique (D515).** **« Nous avons
+besoin de pouvoir paramétrer les échelles, les début et fin d'axe et
+éventuellement quelques éléments d'affichage — affichage de vignettes,
+couleurs, utilisation de dégradé… »** *(Les écritures en proposition,
+réemployant l'existant :* **la forme riche des axes** — `x:` et `y:`
+acceptent `{ value:, min:, max:, scale: }` : `min`/`max` = les début
+et fin d'axe (l'écho D494), `scale: linear` (défaut) `| log` ;
+**`colors:`** — la mécanique D467 réemployée : la couleur par série,
+**le dégradé** compris ; **`points:`** — les vignettes aux points de
+la courbe : la valeur affichée — et au nuage (`chart.scatter`), **le
+visage de l'enregistrement** (D386).)*
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10634,3 +10647,7 @@ avant la synthèse Q16).
   socle au trait droit, « le tracé de la route aux hooks » — le
   patron du géocodage (D294), OSRM/Valhalla en candidats
   auto-hébergeables (Q7).
+- **2026-08-14 (suite 11)** — **Les réglages d'affichage (D515)** :
+  les échelles, les début/fin d'axe, les éléments d'affichage
+  (vignettes, couleurs, dégradé) — la forme riche des axes, colors:
+  D467 et points: en proposition. La fiche chart.line complétée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -597,6 +597,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D516 | **`labels:` et les valeurs du calcul** (amende D515) : « labels: true affiche la valeur dans le format du champ, le gabarit pour personnaliser » ; « en cliquant sur une vignette, voir toutes les valeurs utilisées pour le calcul (si le calcul dépend d'une liste ou d'une association) ». | La collision avec le dictionnaire D440 notée (le contexte départage — D458). Voir §3.2c. |
 | D517 | **L'assise du graphique** : « un chart doit s'appuyer sur une entité ou une liste (composant déjà vu) ; les axes font référence aux champs » — l'entité ou la liste nommée (le périmètre hérité), les axes sur ses champs. | `on:` à l'adresse D439 en proposition (`sales.order[invoiced]`). Voir §3.2c. |
 | D518 | **Le défaut de l'assise** (complète D517) : « si on: est absent, l'assise porte sur l'entité elle-même » — l'entité porteuse ; on: pour désigner ailleurs. | Voir §3.2c. |
+| D519 | **Les secteurs arbitrés** : `mode: pie \| donut \| quarter` ; les variables du gabarit `{value}`/`{percent}`/`{total}` (« {percent} % ({value} / {total}) ») ; le clic sur une part → la liste de ses éléments ; « autres » acté — **son drill affiche une barre de répartition** pour préciser la valeur à filtrer. | Le drill à deux étages. Voir §3.2c. |
 
 ---
 
@@ -3744,6 +3745,20 @@ liste nommée, le crochet de l'adresse.)*
 absent, l'assise porte sur l'entité elle-même »** — l'entité porteuse
 de la déclaration ; `on:` ne s'écrit que pour désigner une autre
 assise (une liste nommée, une autre entité).
+
+**Les secteurs arbitrés (D519).** Les trois virgules de `chart.pie`
+tranchées : **(1) `mode: pie | donut | quarter`** — le quart de cercle
+rejoint le camembert et l'anneau. **(2) Les variables du gabarit des
+labels** : `{percent}` validée — **« cette variable s'ajoute à la
+valeur pouvant être utilisée : "{percent} % ({value} / {total})" »** —
+le trio `{value}`, `{percent}`, `{total}`. **(3) Le clic et les
+« autres »** : « en cliquant sur une valeur, afficher la liste des
+éléments correspondant à la part » (D242) ; le regroupement des
+petites parts en « autres » est acté — **« mais le drill sur autres
+doit afficher une barre avec une répartition de toutes les autres
+valeurs, afin de permettre à l'utilisateur de préciser la valeur à
+filtrer dans la liste »** — **le drill à deux étages** : le secteur →
+la liste ; « autres » → la barre de répartition → la liste.
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10701,3 +10716,8 @@ avant la synthèse Q16).
   proposition (mode: pie|donut au crochet, la variable {percent} au
   gabarit des labels, le regroupement des petites parts en « autres »
   à seuil).
+- **2026-08-14 (suite 17)** — **Les secteurs arbitrés (D519)** :
+  mode: pie|donut|quarter ; les variables {value}/{percent}/{total} ;
+  le clic sur une part → la liste de ses éléments ; « autres » acté,
+  son drill ouvrant une barre de répartition (le drill à deux
+  étages). La fiche chart.pie complétée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -10790,3 +10790,8 @@ avant la synthèse Q16).
   redondance effacée — l'axe porte min/max/threshold, la zone
   s'adresse (zone: [1,1] + title) ; la convention [colonne, ligne]
   depuis l'origine en proposition. La fiche simplifiée.
+- **2026-08-14 (suite 22)** — **La fiche `chart.scatter` validée**
+  (« oui »), la convention [colonne, ligne] depuis l'origine actée.
+  Suivante : `chart.combo` — le combiné (D239 : courbe+barres ou 2
+  courbes, 2 axes Y max) ; en proposition : y: en liste de séries
+  { value:, as: line|bars, axis: left|right }.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -618,6 +618,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D537 | **Le résumé précisé** : « le 1-1 affiche le title **ou l'image** si elle est définie » (le visage D386) ; petit par principe confirmé ; « plusieurs sections (pour mêler des affichages horizontaux et verticaux) — pas plusieurs pages, ni plusieurs tabs ». | L'organisateur D489–D491 dans le résumé ; D201 confirmé. Voir §3.2c. |
 | D538 | **Le graphique au résumé** : « un summary peut contenir un kpi ou un chart — à condition que son affichage reste modeste » (D243 réutilisable, la modestie D201). | `chart[<nom>]` en items en proposition (la famille des adresses D460/D483/D511). Voir §3.2c. |
 | D539 | **La troisième assise du chart** (élargit D517) : « elle s'appuie sur une entité ou un champ de type list of ou association with » — le champ-collection : le graphique des éléments liés à l'enregistrement du contexte. | `on: <champ>` en proposition. Voir §3.2c. |
+| D540 | **Le chart, feuille du formulaire** : « un form peut donc avoir un composant chart comme feuille — nous le faisons entrer de fait dans summary » — `chart[<nom>]` en item du form, le résumé l'héritant (la modestie D538). | Confirme D243/D538. Voir §3.2c. |
 
 ---
 
@@ -3992,6 +3993,13 @@ l'association de l'enregistrement du contexte : le graphique des
 lignes de *la* commande affichée. *(L'écriture en proposition :
 `on: <champ>` — le nom du champ `list of`/`association with` de
 l'entité porteuse.)*
+
+**Le chart, feuille du formulaire (D540).** **« Un form peut donc
+avoir un composant chart comme feuille. Nous le faisons entrer de
+fait dans summary. »** La conséquence est actée : `chart[<nom>]` est
+un item du formulaire au même titre que les feuilles (D243 tenait la
+promesse) — et le résumé, restriction du formulaire (D201), **en
+hérite de fait** — la modestie en condition (D538).
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11075,3 +11083,7 @@ avant la synthèse Q16).
   chart s'appuie sur une entité ou un champ de type list of ou
   association with » — le champ-collection, le graphique des éléments
   liés à l'enregistrement du contexte ; on: <champ> en proposition.
+- **2026-08-14 (suite 45)** — **Le chart, feuille du formulaire
+  (D540)** : « un form peut donc avoir un composant chart comme
+  feuille — nous le faisons entrer de fait dans summary » (la
+  restriction D201 le laisse passer, la modestie D538).

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -10970,3 +10970,9 @@ avant la synthèse Q16).
 - **2026-08-14 (suite 36)** — **La grammaire de size (D533)** : une
   valeur = la part de l'écran centrée ; deux valeurs = largeur puis
   hauteur ; % ou px — partout où size s'écrit (D484).
+- **2026-08-14 (suite 37)** — **La fiche `list` (surface) validée**
+  (« je valide la liste »). Le fil avance : la fiche `form` écrite —
+  les cinq usages (D199), le pages implicite (D509–D510), le titre à
+  gabarit (D449/D465), la surimpression (D454, la grammaire D533) ;
+  la virgule size/dimension au formulaire signalée (D532 évoquait
+  size — la lecture D484 dit dimension, l'extension à l'appel).

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -613,6 +613,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D532 | **`size:` et `screen:` sur la liste** : « comme la form — size pour marquer la zone de couverture de l'écran, screen pour indiquer sur quel support la liste a été définie et/ou autorisée à s'afficher ». | La cohérence D484/D503 et D450. Voir §3.2c. |
 | D533 | **La grammaire de `size:`** : « 75% → 75 % de l'écran avec centrage ; 90% 50% → la longueur et la hauteur ; ou 1000px 320px en pixels » — une valeur centrée, deux valeurs largeur puis hauteur, % ou px. | Vaut partout où size s'écrit (D484). Voir §3.2c. |
 | D534 | **La confusion levée** (clarifie D532) : « j'ai introduit une confusion entre dimension et size » — la doctrine D484 départage : le formulaire s'ouvre à l'appel → `dimension:` (D454) ; la liste s'affiche → `size:` ; la grammaire D533 vaut pour les deux. | Voir §3.2c. |
+| D535 | **`size` aux surfaces, la pile des surimpressions** (amende D454/D534) : « size me convient mieux pour les 2 usages — un form ou une liste apparaissent en surimpression par rapport aux actions antécédentes cumulées » — toute surface s'ouvre au-dessus de la pile ; le couple D484 demeure au grain du champ. | Le dimension: du formulaire (D454) devient size:. Voir §3.2c. |
 
 ---
 
@@ -3934,6 +3935,18 @@ surimpression, l'extension au clic) ; **la liste s'affiche →
 D532 se lit : comme le formulaire porte ses propriétés d'emprise et de
 support, la liste porte les siennes. **La grammaire D533 vaut pour les
 deux mots** — une ou deux valeurs, % ou px.
+
+**`size` aux surfaces, la pile des surimpressions (D535 — amende D454
+et D534).** **« Size me convient mieux pour les 2 usages. Un form ou
+une liste — ou, comme nous le verrons, les autres points —
+apparaissent en surimpression par rapport aux actions antécédentes
+cumulées. »** Les surfaces portent toutes **`size:`** : chacune
+s'ouvre **au-dessus de la pile** des surfaces précédentes — la liste,
+puis le formulaire, puis le sous-formulaire… — la surimpression est
+la règle générale, non une extension particulière. Le `dimension:` du
+formulaire (D454) devient `size:` ; **le couple D484 demeure au grain
+du champ** (la vignette/la visionneuse, la mini-carte/la carte
+dépliée, le picker déployé — `dimension:`).
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10991,3 +11004,8 @@ avant la synthèse Q16).
   départage : le formulaire à l'appel → dimension (D454), la liste à
   l'affichage → size ; la grammaire D533 pour les deux. La fiche form
   confirmée sur dimension:.
+- **2026-08-14 (suite 39)** — **size aux surfaces (D535)** : « size me
+  convient mieux pour les 2 usages » — toute surface s'ouvre en
+  surimpression sur la pile des actions antécédentes cumulées ; le
+  dimension: du formulaire (D454) devient size: ; le couple D484
+  demeure au grain du champ. La fiche form corrigée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -11480,3 +11480,12 @@ avant la synthèse Q16).
   standards ; les limites sur les composants (pas de liste, pas
   d'image — ![…] exclu) ; l'if: d'expression demeure ; la frontière
   D261 préservée (le champ texte utilisateur reste nu).
+- **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
+  (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
+  SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,
+  dashboard, template — D530–D562) sur le fil sales.order. **LE
+  CATALOGUE DE COMPOSANTS.MD EST AU COMPLET : les cinq familles**
+  (les feuilles — 26 fiches, les conteneurs — 4 couples +
+  header/footer, l'acte unique, les graphiques — 7 fiches, les
+  surfaces — 7 fiches). Restent au domaine 4 : la signature formelle
+  des nœuds, puis Q60, les domaines 5–8, la passe de complétude.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -604,6 +604,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D523 | **La matrice adressée** (simplifie D522) : « l'axe définit min, max et threshold ; les zones définissent les positions dans la matrice créée — plutôt que x et y, `zone: [1,1]` » — plus aucune borne répétée. | Convention `[colonne, ligne]` depuis l'origine (bas-gauche) en proposition. Voir §3.2c. |
 | D524 | **L'orientation du combiné** : « axis: left \| right, ou bottom \| up, pour une représentation en ligne contre une représentation en colonne » — la paire d'axes dit l'orientation, homogène par construction. | La virgule « up »/« top » (D504) signalée. Voir §3.2c. |
 | D525 | **`top` harmonisé** (amende D524) : « j'harmonise en effet avec top » — `axis: bottom \| top`, le vocabulaire unique des bords avec les tabs (D504). | Voir §3.2c. |
+| D526 | **L'icône aux seuils** : « je souhaite aussi pouvoir associer éventuellement une icône — cas d'un feu tricolore » — les seuils portent la couleur (D467) et/ou l'icône. | `icons:` en proposition (la mécanique D467 dupliquée ; la collision avec la feuille notée — D458) ; la liaison `icon:` à la table D495. Voir §3.2c. |
 
 ---
 
@@ -3827,6 +3828,17 @@ trancher.)*
 effet avec top »** — la paire couchée s'écrit **`bottom | top`**, le
 vocabulaire unique avec les tabs (D504) : top/bottom/left/right
 partout où un bord se nomme.
+
+**L'icône aux seuils (D526).** **« La combinaison valeur/couleur est
+une approche. Je souhaite aussi pouvoir associer éventuellement une
+icône — cas d'un feu tricolore, par exemple. »** Les seuils portent
+la couleur (D467) **et/ou l'icône** : le feu rouge/orange/vert à côté
+du chiffre. *(L'écriture en proposition : **`icons:`** — la mécanique
+de `colors:` dupliquée, `{ 0: red_light.svg, 50: orange_light.svg,
+80: green_light.svg }` — la collision avec la feuille `icons` notée,
+le contexte départage (D458) ; et la table d'entité (D495) gagne la
+liaison `icon:` en option.)* Vaut où les seuils valent (D467) — le
+`kpi` en usage premier.
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10822,3 +10834,7 @@ avant la synthèse Q16).
   valide chart.combo »). Suivante : `kpi` — le chiffre-clé (value:
   sans axe, colors: par seuils D467, drill D242, pas de comparaison
   au socle D245 — le hook).
+- **2026-08-14 (suite 26)** — **L'icône aux seuils (D526)** : « le
+  feu tricolore » — icons: en proposition (la mécanique D467
+  dupliquée, la collision avec la feuille notée), la liaison icon: à
+  la table D495. La fiche kpi complétée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -612,6 +612,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D531 | **Les actions et l'anatomie de la liste** : `actions:` (l'opération porte son icône, surchargeable) ; « une liste est comme pages » — le header (titre, colonnes, filtres, l'icône-menu des exports, les icônes add/update/delete + actions à icône), la zone page (le tableau), le footer (le sous-total ou un gabarit, les boutons des actions sans icône). | L'icône trie : header ; sans icône : bouton du pied. `{count}` au gabarit en proposition. Voir §3.2c. |
 | D532 | **`size:` et `screen:` sur la liste** : « comme la form — size pour marquer la zone de couverture de l'écran, screen pour indiquer sur quel support la liste a été définie et/ou autorisée à s'afficher ». | La cohérence D484/D503 et D450. Voir §3.2c. |
 | D533 | **La grammaire de `size:`** : « 75% → 75 % de l'écran avec centrage ; 90% 50% → la longueur et la hauteur ; ou 1000px 320px en pixels » — une valeur centrée, deux valeurs largeur puis hauteur, % ou px. | Vaut partout où size s'écrit (D484). Voir §3.2c. |
+| D534 | **La confusion levée** (clarifie D532) : « j'ai introduit une confusion entre dimension et size » — la doctrine D484 départage : le formulaire s'ouvre à l'appel → `dimension:` (D454) ; la liste s'affiche → `size:` ; la grammaire D533 vaut pour les deux. | Voir §3.2c. |
 
 ---
 
@@ -3924,6 +3925,15 @@ pixels. »** Une valeur = la part de l'écran, **centrée** ; deux
 valeurs = **la largeur puis la hauteur** ; l'unité : `%` ou `px`. La
 grammaire vaut **partout où `size` s'écrit** (D484 — la carte, les
 sections, le kpi, la liste…).
+
+**La confusion levée (D534 — clarifie D532).** **« J'ai introduit une
+confusion entre dimension et size. »** La doctrine D484 départage :
+**le formulaire s'ouvre à l'appel → `dimension:`** (D454 — la
+surimpression, l'extension au clic) ; **la liste s'affiche →
+`size:`** (D532 — la couverture de l'écran). Le « comme la form » de
+D532 se lit : comme le formulaire porte ses propriétés d'emprise et de
+support, la liste porte les siennes. **La grammaire D533 vaut pour les
+deux mots** — une ou deux valeurs, % ou px.
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10976,3 +10986,8 @@ avant la synthèse Q16).
   gabarit (D449/D465), la surimpression (D454, la grammaire D533) ;
   la virgule size/dimension au formulaire signalée (D532 évoquait
   size — la lecture D484 dit dimension, l'extension à l'appel).
+- **2026-08-14 (suite 38)** — **La confusion levée (D534)** : « j'ai
+  introduit une confusion entre dimension et size » — D484
+  départage : le formulaire à l'appel → dimension (D454), la liste à
+  l'affichage → size ; la grammaire D533 pour les deux. La fiche form
+  confirmée sur dimension:.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -606,6 +606,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D525 | **`top` harmonisé** (amende D524) : « j'harmonise en effet avec top » — `axis: bottom \| top`, le vocabulaire unique des bords avec les tabs (D504). | Voir §3.2c. |
 | D526 | **L'icône aux seuils** : « je souhaite aussi pouvoir associer éventuellement une icône — cas d'un feu tricolore » — les seuils portent la couleur (D467) et/ou l'icône. | `icons:` en proposition (la mécanique D467 dupliquée ; la collision avec la feuille notée — D458) ; la liaison `icon:` à la table D495. Voir §3.2c. |
 | D527 | **L'organisation du kpi** : « mis en valeur avec un style différent de la feuille » ; « l'organisation se découpe en 4 » — la position du label (haut/gauche/bas/droite), l'icône au bord opposé. | `layout: top \| left \| bottom \| right` en proposition (défaut top ; la collision avec D490 notée). Voir §3.2c. |
+| D528 | **Le tri du croisé sur la valeur** : « visualiser les plus gros CA » — les lignes par la valeur agrégée, chaque niveau du groupement par son sous-total ; le défaut = l'ordre naturel du champ. | `sort: -value` en proposition (le signe D441). Voir §3.2c. |
 
 ---
 
@@ -3852,6 +3853,14 @@ du label, **l'icône au bord opposé**. *(L'écriture en proposition :
 bords du vocabulaire unique (D525) ; défaut `top` — le premier cité ;
 la collision avec le `layout:` des sections (D490) notée, les valeurs
 départagent — D458.)*
+
+**Le tri du croisé sur la valeur (D528).** **« J'ajoute un tri
+également sur la value pour notamment visualiser les plus gros CA,
+par exemple. »** Les lignes s'ordonnent par la valeur agrégée — et
+dans un groupement hiérarchique, **chaque niveau se trie par son
+sous-total** (les commerciaux par leur CA, leurs clients par le
+leur). Le défaut demeure l'ordre naturel du champ. *(L'écriture en
+proposition : `sort: -value` — le signe du tri des listes, D441.)*
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10860,3 +10869,7 @@ avant la synthèse Q16).
   (D246 : les quatre éléments, les groupements pliables) ; en
   proposition : rows:/columns:/value:, le clic sur une cellule
   ouvrant la liste de l'intersection.
+- **2026-08-14 (suite 29)** — **Le tri du croisé (D528)** : « un tri
+  sur la value pour visualiser les plus gros CA » — chaque niveau du
+  groupement par son sous-total, sort: -value en proposition (D441).
+  La fiche pivot complétée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -11027,3 +11027,8 @@ avant la synthèse Q16).
   form ») — et **style: défini (D536)** : le style global de
   l'application en défaut, la surcharge {fonte, taille, mise en
   forme} à la cascade D461. La fiche text complétée.
+- **2026-08-14 (suite 41)** — **style: validé** (« je valide style »).
+  Le fil avance : la fiche `summary` écrite — la config de formulaire
+  restreinte (D201 : les champs sélectionnés, pas d'onglets, petit
+  par principe, le défaut n'existe pas), le visage déployé de la
+  référence (D215).

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -630,6 +630,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D549 | **Les arbitrages du wizard** (amende D548) : « size est optionnel — sans valeur, l'espace disponible ; depuis un menu, tout l'écran » ; « plutôt que mode, je préfère **breadcrumb: none \| top \| bottom** ». | Défaut top (l'esprit D504) ; none masque le fil. Voir §3.2c. |
 | D550 | **L'aide à la décision au parcours** : « nous pouvons inclure des charts, des kpi ou des pivots pour apporter une aide à la décision » — les graphiques aux steps (`chart[<nom>]` — D540). | Voir §3.2c. |
 | D551 | **Un seul wizard** : « tout ce que nous venons de voir avec wizard doit être également porté par tabs[wizard]… car cela doit être le même objet » — la surface et le conteneur, un même composant (l'écho D486) ; seule change la porte d'entrée. | Les fiches wizard et tabs liées. Voir §3.2c. |
+| D552 | **La séparation tabs/wizard** (amende D504, rend D551 caduque) : « je valide la séparation — ça confirme mon ressenti » — le mode wizard quitte tabs (restent top/bottom/left/right), le wizard garde steps/step et sa mécanique, le chemin D505 à lui seul ; deux objets, une parenté visuelle. | La transactionnalité n'est pas un habillage ; if:/operation: orphelines sur un tab libre ; le mot fait la chose. Voir §3.2c. |
 
 ---
 
@@ -4126,6 +4127,22 @@ transformation finale (D547), le cliquet, le header/footer (D548), le
 `breadcrumb:` et le `size:` optionnel (D549), les graphiques (D550) —
 tout vaut des deux côtés ; seule change la porte d'entrée (le menu ou
 l'emboîtement).
+
+**La séparation tabs/wizard (D552 — amende D504/D546, rend D551
+caduque).** La revue demandée (« ça m'embête d'avoir 2 vocabulaires —
+tabs/steps — pour un même objet ») s'est conclue : **« je valide la
+séparation. Ça confirme mon ressenti. »** Les raisons consignées :
+**la transactionnalité n'est pas un habillage** (le contrat du wizard
+— rien avant la validation définitive, le cliquet, la session unique —
+n'est pas un mode d'affichage) ; **les propriétés orphelines
+trahissent** (`if:`/`operation:` sans sens sur un tab libre) ; **le
+mot fait la chose** (step = l'étape d'une démarche, tab = le volet
+d'un classeur). Concrètement : **le mode `wizard` quitte `tabs`**
+(D504 amendé — restent top/bottom/left/right) ; **D551 devient : deux
+objets, une parenté visuelle assumée** ; le wizard garde son
+vocabulaire entier (steps/step, breadcrumb, la mécanique D547) et le
+chemin de traitement (D505) devient son affaire seule ;
+l'emboîtement passe par D455 (le wizard dans une page, sans tabs).
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11283,3 +11300,8 @@ avant la synthèse Q16).
   objet — faut-il sortir wizard de tabs, ou au contraire fusionner
   les 2 ? » — la validation du wizard suspendue, les deux voies
   posées dans l'échange avec recommandation ; l'arbitrage attendu.
+- **2026-08-14 (suite 62)** — **La séparation validée (D552)** : « je
+  valide la séparation. Ça confirme mon ressenti » — le mode wizard
+  retiré de tabs (D504 amendé), D551 caduque (deux objets, une
+  parenté visuelle), le chemin D505 au wizard seul. Les deux fiches
+  reprises.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -640,6 +640,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D559 | **Le template précisé** : `margin:` en mm ; « le paragraph peut être un gabarit — le cas d'une lettre » (le publipostage, l'étoffement Q55) ; « la déclinaison par langue se porte sur chaque item » (amende la lecture de D253 — un seul gabarit, les items déclinés). | Voir §3.2c. |
 | D560 | **Le publipostage étoffé** : « paragraph doit être étoffé pour disposer d'un mode publipostage riche et facile à intégrer » — les cinq briques en proposition : les variables au format de la langue (les chemins D71), l'`if:` conditionnel, `style:`/les titres, la source (en place ou dictionnaire D440), le multi-alinéas. | À arbitrer. Voir §3.2c. |
 | D561 | **La sixième brique** (complète D560) : « l'affichage d'une liste sous forme de bullet points ou d'indices » — la collection dans la lettre. | `{overdue[bullets]}` / `{overdue[numbers]}` en proposition (le crochet ; le `title` D465 par élément). Voir §3.2c. |
+| D562 | **Mustache + markdown au paragraph** (remplace les écritures D560–D561) : « la combinaison doit couvrir les différents cas ; des limites portant sur les composants (pas de liste, pas d'image…) » — mustache (variables, chemins, sections-itérations), markdown (titres, gras, puces, tableaux) ; `![…]` exclu, l'`if:` d'expression demeure (D90), le champ texte utilisateur reste nu (D261). | Deux standards, zéro syntaxe maison. Voir §3.2c. |
 
 ---
 
@@ -4240,6 +4241,24 @@ entre dans la lettre — les commandes en retard énumérées en puces ou
 numérotées. *(L'écriture en proposition : la variable-collection au
 crochet — `{overdue[bullets]}` / `{overdue[numbers]}` — chaque
 élément rendu par son `title` (D465).)*
+
+**Mustache + markdown (D562 — remplace les écritures de D560–D561).**
+**« Une combinaison dans paragraph du mustache et du markdown doit
+couvrir les différents cas, je pense. Il y aura des limites portant
+sur les composants (pas de liste, pas d'image…). »** Deux standards à
+la place des briques maison : **mustache** — les variables
+`{{champ}}`, les chemins `{{customer.name}}` (D71), **les sections**
+`{{#overdue}}…{{/overdue}}` (l'itération des collections — la puce
+markdown dans la section fait la liste D561) ; **markdown** — la
+forme : les titres (`#`…`####` — les quatre niveaux D250), le
+gras/l'italique, les puces et les indices, les tableaux. **Les
+limites** : les composants n'entrent pas dans le texte — pas de
+composant liste, pas d'image (la syntaxe `![…]` exclue — l'image
+reste `picture`, hors du texte) ; **l'`if:` d'expression demeure la
+propriété de l'alinéa** (D90 — mustache est sans logique) ; la source
+(en place ou dictionnaire D440) et le multi-alinéas vont de soi. Le
+champ texte de l'utilisateur reste nu (la frontière D261 — le
+markdown n'entre pas dans la donnée).
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11456,3 +11475,8 @@ avant la synthèse Q16).
   liste sous forme de bullet points ou d'indices » — la
   variable-collection au crochet en proposition ({overdue[bullets]},
   le title par élément).
+- **2026-08-14 (suite 74)** — **Mustache + markdown (D562)** : la
+  combinaison couvre les cas — les briques maison remplacées par deux
+  standards ; les limites sur les composants (pas de liste, pas
+  d'image — ![…] exclu) ; l'if: d'expression demeure ; la frontière
+  D261 préservée (le champ texte utilisateur reste nu).

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -594,6 +594,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D513 | **La carte des collections** : « le composant doit pouvoir s'adapter pour une coordonnée ou une liste de coordonnées dont des lignes sont possibles ou pas » — les marqueurs multiples, le tracé dans l'ordre de la collection. | Rien n'était consigné (vérifié) ; `lines: true \| false` en proposition (défaut false). Voir §3.2c. |
 | D514 | **La frontière de la route** (complète D513) : les lieux d'un produit (sans relier) / le parcours d'un commercial (relié) ; le socle relie au trait droit — **« le tracé de la route, je préfère le laisser aux hooks »** (les abonnements aux outils annexes). | Le patron du géocodage D294 — candidats open source auto-hébergeables : OSRM, Valhalla (Q7). Voir §3.2c. |
 | D515 | **Les réglages d'affichage du graphique** : « paramétrer les échelles, les début et fin d'axe et quelques éléments d'affichage (vignettes, couleurs, dégradé…) ». | En proposition : la forme riche des axes `{ value:, min:, max:, scale: }` (l'écho D494), `colors:` (D467, le dégradé), `points:` (les vignettes — le visage au nuage D386). Voir §3.2c. |
+| D516 | **`labels:` et les valeurs du calcul** (amende D515) : « labels: true affiche la valeur dans le format du champ, le gabarit pour personnaliser » ; « en cliquant sur une vignette, voir toutes les valeurs utilisées pour le calcul (si le calcul dépend d'une liste ou d'une association) ». | La collision avec le dictionnaire D440 notée (le contexte départage — D458). Voir §3.2c. |
 
 ---
 
@@ -3714,6 +3715,18 @@ et fin d'axe (l'écho D494), `scale: linear` (défaut) `| log` ;
 **le dégradé** compris ; **`points:`** — les vignettes aux points de
 la courbe : la valeur affichée — et au nuage (`chart.scatter`), **le
 visage de l'enregistrement** (D386).)*
+
+**`labels:` et les valeurs du calcul (D516 — amende D515).** La
+proposition `points:` s'efface : **« je verrai plutôt `labels`, avec
+un gabarit d'affichage si besoin de personnaliser. Sinon,
+`labels: true` — affiche la valeur dans le format du champ. »** Le
+vrai comme le gabarit *(la collision avec `labels`, le dictionnaire du
+module D440/D465, est notée — le contexte départage, D458)*. Et
+l'interaction : **« en cliquant sur une vignette, je souhaite voir
+toutes les valeurs utilisées pour le calcul (si le calcul dépend
+d'une liste ou d'une association) »** — le détail de l'agrégat
+s'ouvre au clic : les valeurs contributrices (l'écho du drill-down
+D242 et de l'écart assumé des évaluations D248).
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10651,3 +10664,7 @@ avant la synthèse Q16).
   les échelles, les début/fin d'axe, les éléments d'affichage
   (vignettes, couleurs, dégradé) — la forme riche des axes, colors:
   D467 et points: en proposition. La fiche chart.line complétée.
+- **2026-08-14 (suite 12)** — **labels: et les valeurs du calcul
+  (D516)** : labels: true (la valeur au format du champ) ou le
+  gabarit ; le clic sur une vignette ouvre toutes les valeurs du
+  calcul (liste/association). La fiche chart.line ajustée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -10549,3 +10549,8 @@ avant la synthèse Q16).
   besoin de composants complémentaires » (D509). L'auteur clôt la
   séance ; **la prochaine : une passe sur la construction des
   surfaces pour une entité.**
+- **2026-08-14 (suite 6)** — **La PR #24 fusionnée** (« Q16 — le
+  glossaire, le domaine 3, et le domaine 4 : le catalogue des
+  composants, D417–D510 » — 140 commits, 3 fichiers). Develop porte
+  désormais glossaire.md, composants.md et la conception jusqu'à
+  D510.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -610,6 +610,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D529 | **Le tri aux trois clés** (élargit D528) : « le tri peut s'appuyer sur les rows, les columns ou la value » — les signes et cascades D441 (`sort: { seller: -value, date: + }`). | Voir §3.2c. |
 | D530 | **Les appels du geste et les exports** : « add, update or delete pour préciser le formulaire/widget à appeler » (les défauts : le formulaire par défaut D438, les gestes D446) ; « exports: permet de préciser les différents exports ou générations de documents ». | `exports: [ csv, excel[modèle], template[gabarit] ]` en proposition. Voir §3.2c. |
 | D531 | **Les actions et l'anatomie de la liste** : `actions:` (l'opération porte son icône, surchargeable) ; « une liste est comme pages » — le header (titre, colonnes, filtres, l'icône-menu des exports, les icônes add/update/delete + actions à icône), la zone page (le tableau), le footer (le sous-total ou un gabarit, les boutons des actions sans icône). | L'icône trie : header ; sans icône : bouton du pied. `{count}` au gabarit en proposition. Voir §3.2c. |
+| D532 | **`size:` et `screen:` sur la liste** : « comme la form — size pour marquer la zone de couverture de l'écran, screen pour indiquer sur quel support la liste a été définie et/ou autorisée à s'afficher ». | La cohérence D484/D503 et D450. Voir §3.2c. |
 
 ---
 
@@ -3906,6 +3907,14 @@ est comme pages »** (D507/D509) :
 La répartition est réglée d'elle-même : l'action à icône monte au
 header, l'action sans icône devient bouton du pied. *(En proposition :
 le gabarit du pied aux variables — `{count}` le nombre de lignes.)*
+
+**`size:` et `screen:` sur la liste (D532).** **« Comme la form, la
+liste porte aussi une propriété `size` pour marquer la zone de
+couverture de l'écran, et l'option `screen` pour indiquer sur quel
+support la liste a été définie et/ou autorisée à s'afficher. »** La
+cohérence s'étend : `size` = la couverture à l'affichage (D484/D503),
+`screen` = le support de conception **et** l'autorisation (D450 — le
+tableau `[pc paysage]` en défaut).
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10946,3 +10955,6 @@ avant la synthèse Q16).
   des gestes et actions), la zone page (le tableau), footer
   (sous-total ou gabarit + les boutons des actions sans icône). La
   fiche restructurée.
+- **2026-08-14 (suite 35)** — **size et screen sur la liste (D532)** :
+  la couverture de l'écran (D484/D503) et le support de conception
+  et/ou d'autorisation (D450). La fiche complétée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -11087,3 +11087,8 @@ avant la synthèse Q16).
   (D540)** : « un form peut donc avoir un composant chart comme
   feuille — nous le faisons entrer de fait dans summary » (la
   restriction D201 le laisse passer, la modestie D538).
+- **2026-08-14 (suite 46)** — **`summary` et `on: <champ>` validés**
+  (« je valide summary et on: <champ> »). Le fil avance : la fiche
+  `widget` écrite — la lecture proposée : une seule surface aux deux
+  usages, la carte de l'enregistrement (D492) et la synthèse au
+  drill-down (D202), le pool de l'accueil (D204), l'évaluation D248.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -643,6 +643,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D562 | **Mustache + markdown au paragraph** (remplace les écritures D560–D561) : « la combinaison doit couvrir les différents cas ; des limites portant sur les composants (pas de liste, pas d'image…) » — mustache (variables, chemins, sections-itérations), markdown (titres, gras, puces, tableaux) ; `![…]` exclu, l'`if:` d'expression demeure (D90), le champ texte utilisateur reste nu (D261). | Deux standards, zéro syntaxe maison. Voir §3.2c. |
 | D563 | **Le comportement d'`url`** (les cinq points validés) : le lien en lecture — le clic ouvre dans un nouvel onglet, l'icône du lien externe en post-zone (D271/D391) ; l'icône demeure en saisie ; l'ellipse en cellule ; le lien actif au template, la valeur nue en Excel/CSV ; l'aperçu de la cible = un hook (D263). | La synthèse complétée (la ligne url séparée). Voir §3.2c. |
 | D564 | **Les quatre destinations du template** : « générer un document Word, PDF, Excel ou un mail — le template porte une propriété `format` qui précise le format de destination ». | `format: pdf \| word \| excel \| mail` (défaut pdf en proposition) ; le mail = le publipostage D562, l'Excel = le modèle D445. Voir §3.2c. |
+| D565 | **Le défaut et l'extension** (solde D564) : « le format pourra être étendu à d'autres formats en fonction des besoins à venir. PDF en défaut me convient. » | La ligne des hooks (D408). Voir §3.2c. |
 
 ---
 
@@ -4284,6 +4285,12 @@ reste le défaut naturel, *en proposition*) : **`format: pdf | word |
 excel | mail`**. Le mail rejoint le publipostage (D562) — la lettre
 mustache+markdown devient le corps du message ; l'Excel rejoint le
 modèle des exports (D445).
+
+**Le défaut et l'extension (D565 — solde D564).** **« Le format
+pourra être étendu à d'autres formats en fonction des besoins à
+venir. PDF en défaut me convient. »** Le défaut `pdf` acté ; le
+catalogue des formats s'étend par les besoins — la ligne des hooks
+(D408), sans toucher au moteur.
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11518,6 +11525,9 @@ avant la synthèse Q16).
   destination (défaut pdf en proposition) ; le mail rejoint le
   publipostage (D562). La fiche complétée — le commit rejoint la PR
   #25 ouverte.
+- **2026-08-14 (suite 79)** — **Le défaut pdf acté (D565)** : « le
+  format pourra être étendu à d'autres formats en fonction des
+  besoins à venir » — la ligne des hooks (D408).
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -631,6 +631,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D550 | **L'aide à la décision au parcours** : « nous pouvons inclure des charts, des kpi ou des pivots pour apporter une aide à la décision » — les graphiques aux steps (`chart[<nom>]` — D540). | Voir §3.2c. |
 | D551 | **Un seul wizard** : « tout ce que nous venons de voir avec wizard doit être également porté par tabs[wizard]… car cela doit être le même objet » — la surface et le conteneur, un même composant (l'écho D486) ; seule change la porte d'entrée. | Les fiches wizard et tabs liées. Voir §3.2c. |
 | D552 | **La séparation tabs/wizard** (amende D504, rend D551 caduque) : « je valide la séparation — ça confirme mon ressenti » — le mode wizard quitte tabs (restent top/bottom/left/right), le wizard garde steps/step et sa mécanique, le chemin D505 à lui seul ; deux objets, une parenté visuelle. | La transactionnalité n'est pas un habillage ; if:/operation: orphelines sur un tab libre ; le mot fait la chose. Voir §3.2c. |
+| D553 | **Le contexte empilé de l'opération** : « le contexte ne représente pas seulement les informations de l'appel en cours mais l'ensemble des contextes qui se sont empilés jusqu'à l'usage de l'opération » — la pile des contextes, le pendant de D535 ; « l'origine de l'appel » (D455) = la pile entière. | Voir §3.2c. |
 
 ---
 
@@ -4143,6 +4144,17 @@ objets, une parenté visuelle assumée** ; le wizard garde son
 vocabulaire entier (steps/step, breadcrumb, la mécanique D547) et le
 chemin de traitement (D505) devient son affaire seule ;
 l'emboîtement passe par D455 (le wizard dans une page, sans tabs).
+
+**Le contexte empilé de l'opération (D553).** **« Pour une opération,
+le contexte ne représente pas seulement les informations de l'appel
+en cours mais l'ensemble des contextes qui se sont empilés jusqu'à
+l'usage de l'opération. »** La pile des surimpressions (D535) a son
+pendant de données : **la pile des contextes** — l'opération invoquée
+au fond de la pile (la liste → le formulaire → le wizard → le step)
+voit tout ce qui s'est empilé : le périmètre de la liste,
+l'enregistrement du formulaire, le transitoire du wizard.
+« L'origine de l'appel » de D455 se relit : **la pile entière, pas le
+dernier maillon.**
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11305,3 +11317,9 @@ avant la synthèse Q16).
   retiré de tabs (D504 amendé), D551 caduque (deux objets, une
   parenté visuelle), le chemin D505 au wizard seul. Les deux fiches
   reprises.
+- **2026-08-14 (suite 63)** — **Le contexte empilé (D553)** :
+  l'opération voit « l'ensemble des contextes qui se sont empilés
+  jusqu'à son usage » — la pile des contextes, le pendant de la pile
+  des surimpressions (D535) ; l'origine de l'appel (D455) = la pile
+  entière. La fiche operation complétée. *(Le commit 6efcb72
+  annonçait D553 par erreur — le voici réellement porté.)*

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -595,6 +595,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D514 | **La frontière de la route** (complète D513) : les lieux d'un produit (sans relier) / le parcours d'un commercial (relié) ; le socle relie au trait droit — **« le tracé de la route, je préfère le laisser aux hooks »** (les abonnements aux outils annexes). | Le patron du géocodage D294 — candidats open source auto-hébergeables : OSRM, Valhalla (Q7). Voir §3.2c. |
 | D515 | **Les réglages d'affichage du graphique** : « paramétrer les échelles, les début et fin d'axe et quelques éléments d'affichage (vignettes, couleurs, dégradé…) ». | En proposition : la forme riche des axes `{ value:, min:, max:, scale: }` (l'écho D494), `colors:` (D467, le dégradé), `points:` (les vignettes — le visage au nuage D386). Voir §3.2c. |
 | D516 | **`labels:` et les valeurs du calcul** (amende D515) : « labels: true affiche la valeur dans le format du champ, le gabarit pour personnaliser » ; « en cliquant sur une vignette, voir toutes les valeurs utilisées pour le calcul (si le calcul dépend d'une liste ou d'une association) ». | La collision avec le dictionnaire D440 notée (le contexte départage — D458). Voir §3.2c. |
+| D517 | **L'assise du graphique** : « un chart doit s'appuyer sur une entité ou une liste (composant déjà vu) ; les axes font référence aux champs » — l'entité ou la liste nommée (le périmètre hérité), les axes sur ses champs. | `on:` à l'adresse D439 en proposition (`sales.order[invoiced]`). Voir §3.2c. |
 
 ---
 
@@ -3727,6 +3728,16 @@ toutes les valeurs utilisées pour le calcul (si le calcul dépend
 d'une liste ou d'une association) »** — le détail de l'agrégat
 s'ouvre au clic : les valeurs contributrices (l'écho du drill-down
 D242 et de l'écart assumé des évaluations D248).
+
+**L'assise du graphique (D517).** **« Un composant chart doit
+s'appuyer sur une entité ou une liste (composant déjà vu). Les axes
+font référence aux champs. »** La déclaration se fonde : **l'assise**
+— une entité, ou **une liste nommée** dont le périmètre (filtre,
+confidentialité) s'hérite — et **les axes référencent les champs de
+l'assise** (`x:` un champ à découpage, `y:` l'agrégat d'un champ).
+*(L'écriture en proposition : **`on:`** à l'adresse D439 —
+`on: sales.order` pour l'entité, `on: sales.order[invoiced]` pour la
+liste nommée, le crochet de l'adresse.)*
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10668,3 +10679,7 @@ avant la synthèse Q16).
   (D516)** : labels: true (la valeur au format du champ) ou le
   gabarit ; le clic sur une vignette ouvre toutes les valeurs du
   calcul (liste/association). La fiche chart.line ajustée.
+- **2026-08-14 (suite 13)** — **L'assise du graphique (D517)** :
+  « s'appuyer sur une entité ou une liste ; les axes font référence
+  aux champs » — on: à l'adresse D439 en proposition, le périmètre de
+  la liste hérité. La fiche chart.line ancrée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -599,6 +599,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D518 | **Le défaut de l'assise** (complète D517) : « si on: est absent, l'assise porte sur l'entité elle-même » — l'entité porteuse ; on: pour désigner ailleurs. | Voir §3.2c. |
 | D519 | **Les secteurs arbitrés** : `mode: pie \| donut \| quarter` ; les variables du gabarit `{value}`/`{percent}`/`{total}` (« {percent} % ({value} / {total}) ») ; le clic sur une part → la liste de ses éléments ; « autres » acté — **son drill affiche une barre de répartition** pour préciser la valeur à filtrer. | Le drill à deux étages. Voir §3.2c. |
 | D520 | **L'épaisseur et les angles** (complète D519) : « sur donut, l'épaisseur ; sur quarter, l'angle de départ, de fin et l'épaisseur — représenter l'assemblée nationale de la gauche vers la droite ». | `thickness:` et les angles aux bornes (`quarter[-90..90]`) en proposition ; l'hémicycle fondateur. Voir §3.2c. |
+| D521 | **Le graphique, le tableau, ou les deux** (au socle des charts) : « les charts doivent se présenter soit en graphique, soit sous forme d'un tableau — pour avoir une vue sur les différentes valeurs directement — ou les deux ». | L'écho des tableaux de valeurs D244 ; `display: graph \| table \| both` en proposition (défaut graph). Voir §3.2c. |
 
 ---
 
@@ -3771,6 +3772,14 @@ l'anneau ou de l'arc, en pourcentage du rayon ; **les angles au
 crochet aux bornes** — `quarter[-90..90]`, l'écho de D366/D497 — le
 départ..la fin en degrés, 0° à midi, le sens horaire ; `quarter` nu =
 `[0..90]`, le quart ; l'hémicycle = `quarter[-90..90]`.)*
+
+**Le graphique, le tableau, ou les deux (D521 — au socle des
+charts).** **« Les charts doivent se présenter soit en graphique, soit
+sous forme d'un tableau (pour avoir une vue sur les différentes
+valeurs directement), ou les deux. »** La présentation rejoint le
+socle commun de la famille — l'écho des tableaux de valeurs (D244).
+*(L'écriture en proposition : `display: graph | table | both` —
+défaut `graph`.)*
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10737,3 +10746,8 @@ avant la synthèse Q16).
   thickness: sur donut/quarter ; les angles de quarter au crochet aux
   bornes (quarter[-90..90] en proposition) — l'hémicycle de
   l'assemblée nationale en usage fondateur.
+- **2026-08-14 (suite 19)** — **La fiche `chart.pie` validée** (« je
+  valide chart.pie ») — et **le tableau au socle (D521)** : « les
+  charts doivent se présenter soit en graphique, soit sous forme d'un
+  tableau, ou les deux » (l'écho D244) ; display: graph|table|both en
+  proposition. Suivante : chart.scatter.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -589,6 +589,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D508 | **La navigation des pages = celle des tabs** : « les pages ont un numéro (par défaut), nous pouvons lui affecter un nom et/ou un icône comme un tab — l'affichage suit la même logique que tabs » (les modes D504, le chemin D505, le swipe). | Voir §3.2c. |
 | D509 | **Le formulaire est un `pages` implicite, `body` disparaît** (amende D449/D455/D490) : « pages est le premier composant d'un formulaire sans avoir besoin de le déclarer ; header et footer sont déjà décrits ; body est à remplacer par page » — et « pas besoin de composants complémentaires » : les conteneurs sont au complet. | La clé `page:` remplace `body:` (30 occurrences balayées) ; le multi-pages à préciser. Voir §3.2c. |
 | D510 | **Le multi-pages en liste** : « le multi-pages se fait à l'aide d'une liste d'éléments — default: [ { header: … }, { page: … }, { page: … }, { footer: … } ] » — les clés pour l'usuel, la liste dès que les pages se répètent. | Solde la virgule D509. Voir §3.2c. |
+| D511 | **L'acte et les deux modes** : « operation[<nom>] pour être en phase avec les fields » ; « une opération doit avoir 2 modes — la pré-exécution identifie les modifications à apporter (les factures à créer ; l'import : ajoutées/modifiées/non modifiées/supprimées) » ; le message de confirmation au gabarit nourri de la pré-exécution. | Généralise D234 et l'exécution à blanc ; `validate: { message: }` en proposition (étend D431). Voir §3.2c. |
 
 ---
 
@@ -3644,6 +3645,25 @@ multi-pages se fait à l'aide d'une liste d'éléments :
 `default: [ { header: … }, { page: … }, { page: … }, { footer: … } ]`. »**
 Deux plumes pour le même `pages` implicite : **les clés** pour l'usuel
 (une page), **la liste d'éléments** dès que les pages se répètent.
+
+**L'acte : `operation[<nom>]` et les deux modes de l'opération
+(D511).** L'écriture actée : **« `operation[<nom>]` pour être en phase
+avec les fields »** (l'écho de `field[<nom>]` D460 et `template[<nom>]`
+D483). Et le concept s'approfondit : **« une opération doit avoir 2
+modes : une pré-exécution permet d'identifier les modifications à
+apporter — par exemple, calculer le nombre de factures à créer, ou
+lors de l'import d'un fichier CSV, le nombre de lignes ajoutées,
+modifiées, non modifiées et supprimées. Cela donne du contexte à
+l'utilisateur avant que l'opération ne soit réellement exécutée. »**
+La pré-exécution **généralise** le dry-run de l'import (D234) et
+l'exécution à blanc du glossaire — toute opération sait se jouer à
+blanc. Et **« un message de confirmation avec un gabarit dont les
+informations sont issues de l'opération en mode pré-exécution »** —
+la relecture de D431 s'enrichit du contexte chiffré. *(L'écriture en
+proposition : `validate: true` — la relecture simple, le défaut —
+s'étend en `validate: { message: <gabarit> }`, le gabarit consommant
+les résultats nommés de la pré-exécution : « {invoices} factures
+seront créées ».)*
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10554,3 +10574,10 @@ avant la synthèse Q16).
   composants, D417–D510 » — 140 commits, 3 fichiers). Develop porte
   désormais glossaire.md, composants.md et la conception jusqu'à
   D510.
+- **2026-08-14 (suite 7)** — **Les actes ouverts (D511)** : la fiche
+  unique tranchée par l'usage, operation[<nom>] acté (« en phase avec
+  les fields ») ; les deux modes de l'opération — la pré-exécution
+  (le contexte chiffré avant l'engagement, la généralisation du
+  dry-run D234) ; le message de confirmation au gabarit
+  (validate: { message: } en proposition). La fiche operation
+  écrite, en attente de validation.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -11323,3 +11323,10 @@ avant la synthèse Q16).
   des surimpressions (D535) ; l'origine de l'appel (D455) = la pile
   entière. La fiche operation complétée. *(Le commit 6efcb72
   annonçait D553 par erreur — le voici réellement porté.)*
+- **2026-08-14 (suite 64)** — **Les fiches `tabs` et `wizard`
+  validées après séparation** (« je valide tabs et wizard »). Le fil
+  avance : la fiche `dashboard` écrite — la surface du module
+  (module[dashboard] D439), les trois rafraîchissements (D249), les
+  widgets assemblés ; en proposition : le bloc dashboards: au module,
+  refresh: static|live|every[…] (D434), widget[<entité>.<nom>]
+  (la famille des adresses).

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -627,6 +627,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D546 | **Le wizard précisé** : steps/step = « un habillage de tabs[wizard] où chaque step est un tab » ; « un step peut contenir une opération sur la validation » ; les opérations de base de toute entité (create/read/update/delete, enrichies) ; la démarche guidée — créer, modifier/supprimer un ensemble d'une liste, **imprimer les menus**, mettre à jour une tournée. | `operation: <nom>` au step en proposition. Voir §3.2c. |
 | D547 | **La chaîne de pré-exécutions** (amende D546) : « le mode draft s'efface… les steps avec une opération sont pré-exécutés ; la transformation n'aura lieu qu'à la validation définitive du wizard » ; « avec un message de confirmation, si l'utilisateur valide, il ne pourra pas revenir en arrière » — le cliquet sur le chemin D505. | `draft:` retiré ; la transaction finale D232/D101 exécute tout. Voir §3.2c. |
 | D548 | **L'anatomie du wizard** : « un header et un footer ; le fil d'Ariane en bas ou en haut de la zone ; une dimension (size) surchargeable si le wizard s'inclut dans un formulaire ». | `mode: top \| bottom` en proposition (D525) ; l'écho pages D507 ; le plus proche l'emporte (D461). Voir §3.2c. |
+| D549 | **Les arbitrages du wizard** (amende D548) : « size est optionnel — sans valeur, l'espace disponible ; depuis un menu, tout l'écran » ; « plutôt que mode, je préfère **breadcrumb: none \| top \| bottom** ». | Défaut top (l'esprit D504) ; none masque le fil. Voir §3.2c. |
 
 ---
 
@@ -4098,6 +4099,13 @@ des steps ; **le fil d'Ariane** (le chemin D505) en haut ou en bas —
 D525)* ; **`size:` obligatoire** (la pile D535, la grammaire D533),
 **surchargeable au nœud incluant** quand le wizard s'emboîte dans un
 formulaire (D455 — le plus proche l'emporte, D461).
+
+**Les deux arbitrages (D549 — amende D548).** **« `size` est
+optionnel. Sans valeur, ça prend l'espace disponible. En cas d'appel
+depuis un menu, le wizard prend tout l'écran. »** Et le nom du fil :
+**« plutôt que mode, je préfère `breadcrumb: none | top | bottom`. »**
+— `none` masque le fil d'Ariane ; le défaut `top` (les étapes
+visibles — l'esprit D504).
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11239,3 +11247,7 @@ avant la synthèse Q16).
   haut ou en bas (mode: top|bottom en proposition) ; size:
   obligatoire, surchargeable à l'inclusion dans un formulaire. La
   fiche complétée.
+- **2026-08-14 (suite 58)** — **Les arbitrages du wizard (D549)** :
+  size optionnel (sans valeur l'espace disponible, tout l'écran
+  depuis un menu) ; breadcrumb: none|top|bottom (défaut top). La
+  fiche ajustée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -628,6 +628,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D547 | **La chaîne de pré-exécutions** (amende D546) : « le mode draft s'efface… les steps avec une opération sont pré-exécutés ; la transformation n'aura lieu qu'à la validation définitive du wizard » ; « avec un message de confirmation, si l'utilisateur valide, il ne pourra pas revenir en arrière » — le cliquet sur le chemin D505. | `draft:` retiré ; la transaction finale D232/D101 exécute tout. Voir §3.2c. |
 | D548 | **L'anatomie du wizard** : « un header et un footer ; le fil d'Ariane en bas ou en haut de la zone ; une dimension (size) surchargeable si le wizard s'inclut dans un formulaire ». | `mode: top \| bottom` en proposition (D525) ; l'écho pages D507 ; le plus proche l'emporte (D461). Voir §3.2c. |
 | D549 | **Les arbitrages du wizard** (amende D548) : « size est optionnel — sans valeur, l'espace disponible ; depuis un menu, tout l'écran » ; « plutôt que mode, je préfère **breadcrumb: none \| top \| bottom** ». | Défaut top (l'esprit D504) ; none masque le fil. Voir §3.2c. |
+| D550 | **L'aide à la décision au parcours** : « nous pouvons inclure des charts, des kpi ou des pivots pour apporter une aide à la décision » — les graphiques aux steps (`chart[<nom>]` — D540). | Voir §3.2c. |
 
 ---
 
@@ -4106,6 +4107,13 @@ depuis un menu, le wizard prend tout l'écran. »** Et le nom du fil :
 **« plutôt que mode, je préfère `breadcrumb: none | top | bottom`. »**
 — `none` masque le fil d'Ariane ; le défaut `top` (les étapes
 visibles — l'esprit D504).
+
+**L'aide à la décision au parcours (D550).** **« Bien sûr, nous
+pouvons inclure des charts, des kpi ou des pivots pour apporter une
+aide à la décision. »** Les graphiques entrent aux steps
+(`chart[<nom>]` — D540, la famille entière) : le chiffre, la courbe
+ou le croisé éclairent le choix avant le passage — l'aide à la
+décision au fil du parcours guidé.
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11251,3 +11259,6 @@ avant la synthèse Q16).
   size optionnel (sans valeur l'espace disponible, tout l'écran
   depuis un menu) ; breadcrumb: none|top|bottom (défaut top). La
   fiche ajustée.
+- **2026-08-14 (suite 59)** — **L'aide à la décision (D550)** : les
+  charts, kpi et pivots aux steps du wizard (chart[<nom>] — D540) —
+  la 550e décision.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -596,6 +596,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D515 | **Les réglages d'affichage du graphique** : « paramétrer les échelles, les début et fin d'axe et quelques éléments d'affichage (vignettes, couleurs, dégradé…) ». | En proposition : la forme riche des axes `{ value:, min:, max:, scale: }` (l'écho D494), `colors:` (D467, le dégradé), `points:` (les vignettes — le visage au nuage D386). Voir §3.2c. |
 | D516 | **`labels:` et les valeurs du calcul** (amende D515) : « labels: true affiche la valeur dans le format du champ, le gabarit pour personnaliser » ; « en cliquant sur une vignette, voir toutes les valeurs utilisées pour le calcul (si le calcul dépend d'une liste ou d'une association) ». | La collision avec le dictionnaire D440 notée (le contexte départage — D458). Voir §3.2c. |
 | D517 | **L'assise du graphique** : « un chart doit s'appuyer sur une entité ou une liste (composant déjà vu) ; les axes font référence aux champs » — l'entité ou la liste nommée (le périmètre hérité), les axes sur ses champs. | `on:` à l'adresse D439 en proposition (`sales.order[invoiced]`). Voir §3.2c. |
+| D518 | **Le défaut de l'assise** (complète D517) : « si on: est absent, l'assise porte sur l'entité elle-même » — l'entité porteuse ; on: pour désigner ailleurs. | Voir §3.2c. |
 
 ---
 
@@ -3738,6 +3739,11 @@ l'assise** (`x:` un champ à découpage, `y:` l'agrégat d'un champ).
 *(L'écriture en proposition : **`on:`** à l'adresse D439 —
 `on: sales.order` pour l'entité, `on: sales.order[invoiced]` pour la
 liste nommée, le crochet de l'adresse.)*
+
+**Le défaut de l'assise (D518 — complète D517).** **« Si `on:` est
+absent, l'assise porte sur l'entité elle-même »** — l'entité porteuse
+de la déclaration ; `on:` ne s'écrit que pour désigner une autre
+assise (une liste nommée, une autre entité).
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10683,3 +10689,6 @@ avant la synthèse Q16).
   « s'appuyer sur une entité ou une liste ; les axes font référence
   aux champs » — on: à l'adresse D439 en proposition, le périmètre de
   la liste hérité. La fiche chart.line ancrée.
+- **2026-08-14 (suite 14)** — **Le défaut de l'assise (D518)** : « si
+  on: est absent, l'assise porte sur l'entité elle-même » — l'entité
+  porteuse de la déclaration.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -10883,3 +10883,10 @@ avant la synthèse Q16).
 - **2026-08-14 (suite 30)** — **Le tri aux trois clés (D529)** : « le
   tri peut s'appuyer sur les rows, les columns ou la value » — les
   signes et cascades D441.
+- **2026-08-14 (suite 31)** — **La fiche `pivot` validée** (« je
+  valide pivot ») — **la famille des graphiques est soldée** : sept
+  fiches (chart.line, chart.bars, chart.pie, chart.scatter,
+  chart.combo, kpi, pivot — D512–D529). Quatre familles sur cinq au
+  complet (les feuilles, les conteneurs, les actes, les graphiques) ;
+  **ne restent que les surfaces — la passe réservée : la construction
+  des surfaces pour une entité.**

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -622,6 +622,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D541 | **La tendance du kpi** (note pour plus tard) : « en exploitant l'historique d'une entité, nous pourrions présenter la tendance » — la valeur rejouée aux instants passés (D411/D172) ; le détail différé. | La frontière avec D245 à confirmer au moment venu. Voir §3.2c. |
 | D542 | **`qrcode` et `barcode` fichés** (répare un manque) : décidés (D252/D300 — les composants de sortie) mais absents de l'inventaire des fiches — les deux feuilles jumelles ajoutées, la fiche commune. | `barcode[ean13\|code128…]` au crochet en proposition (défaut code128) ; le scan hors D300. Voir §3.2c. |
 | D543 | **Le `size` des jumeaux** : le qrcode — « la taille unique pour les côtés » (`size: 120px`, le carré) ; le code-barres — « largeur × hauteur » (la grammaire D533). | Voir §3.2c. |
+| D544 | **Les deux modes du champ encodé** (précise D300/D543) : « la saisie en mode texte et l'affichage en mode graphique — la saisie peut nécessiter une size différente de l'affichage ». | `size: { input:, display: }` en proposition (la forme courte = l'affichage seul). Voir §3.2c. |
 
 ---
 
@@ -4033,6 +4034,16 @@ la taille unique pour les côtés : `size: 120px` — un qrcode de 120 px
 de côté. Pour le code-barres, `size` fournit une taille en largeur ×
 hauteur. »** Le carré par nature (une seule valeur — jamais deux), le
 rectangle à la grammaire pleine (D533).
+
+**Les deux modes du champ encodé (D544 — précise D300/D543).**
+**« C'est un champ qui se décline en 2 modes : la saisie en mode
+texte et l'affichage en mode graphique. La saisie peut nécessiter une
+size différente de l'affichage. »** Le composant de sortie (D300) se
+précise : **la saisie est la zone de texte du champ** (le régime du
+texte — la taille D366, le masque), **l'affichage est le graphique**
+— et chacun peut porter sa taille. *(L'écriture en proposition :
+`size: { input: …, display: … }` — la forme courte `size: 120px` =
+l'affichage seul, la saisie restant au régime du texte.)*
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11142,3 +11153,7 @@ avant la synthèse Q16).
 - **2026-08-14 (suite 50)** — **Le size des jumeaux (D543)** : le
   qrcode au carré (une valeur unique — le côté), le code-barres en
   largeur × hauteur (D533). La fiche complétée.
+- **2026-08-14 (suite 51)** — **Les deux modes du champ encodé
+  (D544)** : la saisie en mode texte (le régime du champ), l'affichage
+  en mode graphique — chacun sa taille ; size: { input:, display: }
+  en proposition.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -626,6 +626,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D545 | **La valeur sous les barres** : « l'affichage du code-barres peut nécessiter l'affichage de la valeur de la référence sous le code-barres » — l'humain sous la machine. | `labels: true` en proposition (l'écho D516, défaut false). Voir §3.2c. |
 | D546 | **Le wizard précisé** : steps/step = « un habillage de tabs[wizard] où chaque step est un tab » ; « un step peut contenir une opération sur la validation » ; les opérations de base de toute entité (create/read/update/delete, enrichies) ; la démarche guidée — créer, modifier/supprimer un ensemble d'une liste, **imprimer les menus**, mettre à jour une tournée. | `operation: <nom>` au step en proposition. Voir §3.2c. |
 | D547 | **La chaîne de pré-exécutions** (amende D546) : « le mode draft s'efface… les steps avec une opération sont pré-exécutés ; la transformation n'aura lieu qu'à la validation définitive du wizard » ; « avec un message de confirmation, si l'utilisateur valide, il ne pourra pas revenir en arrière » — le cliquet sur le chemin D505. | `draft:` retiré ; la transaction finale D232/D101 exécute tout. Voir §3.2c. |
+| D548 | **L'anatomie du wizard** : « un header et un footer ; le fil d'Ariane en bas ou en haut de la zone ; une dimension (size) surchargeable si le wizard s'inclut dans un formulaire ». | `mode: top \| bottom` en proposition (D525) ; l'écho pages D507 ; le plus proche l'emporte (D461). Voir §3.2c. |
 
 ---
 
@@ -4086,6 +4087,17 @@ définitive** — la transaction finale (D232/D101) exécute tout d'un
 coup ; **la confirmation validée barre le retour** — le chemin
 navigable (D505) s'arrête au dernier step confirmé (le cliquet) ; la
 proposition `draft:` est retirée — la pré-exécution la remplace.
+
+**L'anatomie du wizard (D548).** **« Un wizard peut avoir un header
+et un footer. Le fil d'Ariane peut être affiché en bas ou en haut de
+la zone. Un wizard doit avoir une dimension (`size`), surchargeable
+si le wizard s'inclut dans un formulaire. »** L'écho de `pages`
+(D507) : l'entête et le pied optionnels, toujours visibles autour
+des steps ; **le fil d'Ariane** (le chemin D505) en haut ou en bas —
+*(en proposition : `mode: top` (défaut) `| bottom` — les bords
+D525)* ; **`size:` obligatoire** (la pile D535, la grammaire D533),
+**surchargeable au nœud incluant** quand le wizard s'emboîte dans un
+formulaire (D455 — le plus proche l'emporte, D461).
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11222,3 +11234,8 @@ avant la synthèse Q16).
   transformation à la validation définitive ; la confirmation validée
   barre le retour (le cliquet sur le chemin D505). La fiche
   corrigée.
+- **2026-08-14 (suite 57)** — **L'anatomie du wizard (D548)** :
+  header/footer optionnels (l'écho pages D507) ; le fil d'Ariane en
+  haut ou en bas (mode: top|bottom en proposition) ; size:
+  obligatoire, surchargeable à l'inclusion dans un formulaire. La
+  fiche complétée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -598,6 +598,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D517 | **L'assise du graphique** : « un chart doit s'appuyer sur une entité ou une liste (composant déjà vu) ; les axes font référence aux champs » — l'entité ou la liste nommée (le périmètre hérité), les axes sur ses champs. | `on:` à l'adresse D439 en proposition (`sales.order[invoiced]`). Voir §3.2c. |
 | D518 | **Le défaut de l'assise** (complète D517) : « si on: est absent, l'assise porte sur l'entité elle-même » — l'entité porteuse ; on: pour désigner ailleurs. | Voir §3.2c. |
 | D519 | **Les secteurs arbitrés** : `mode: pie \| donut \| quarter` ; les variables du gabarit `{value}`/`{percent}`/`{total}` (« {percent} % ({value} / {total}) ») ; le clic sur une part → la liste de ses éléments ; « autres » acté — **son drill affiche une barre de répartition** pour préciser la valeur à filtrer. | Le drill à deux étages. Voir §3.2c. |
+| D520 | **L'épaisseur et les angles** (complète D519) : « sur donut, l'épaisseur ; sur quarter, l'angle de départ, de fin et l'épaisseur — représenter l'assemblée nationale de la gauche vers la droite ». | `thickness:` et les angles aux bornes (`quarter[-90..90]`) en proposition ; l'hémicycle fondateur. Voir §3.2c. |
 
 ---
 
@@ -3759,6 +3760,17 @@ doit afficher une barre avec une répartition de toutes les autres
 valeurs, afin de permettre à l'utilisateur de préciser la valeur à
 filtrer dans la liste »** — **le drill à deux étages** : le secteur →
 la liste ; « autres » → la barre de répartition → la liste.
+
+**L'épaisseur et les angles (D520 — complète D519).** **« Sur donut,
+une propriété sur l'épaisseur doit être possible. Sur quarter,
+l'angle de départ, de fin et l'épaisseur. Par exemple, quarter doit me
+permettre de représenter l'assemblée nationale avec ses représentants
+de la gauche vers la droite… »** — l'hémicycle en usage fondateur.
+*(Les écritures en proposition : **`thickness:`** — l'épaisseur de
+l'anneau ou de l'arc, en pourcentage du rayon ; **les angles au
+crochet aux bornes** — `quarter[-90..90]`, l'écho de D366/D497 — le
+départ..la fin en degrés, 0° à midi, le sens horaire ; `quarter` nu =
+`[0..90]`, le quart ; l'hémicycle = `quarter[-90..90]`.)*
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10721,3 +10733,7 @@ avant la synthèse Q16).
   le clic sur une part → la liste de ses éléments ; « autres » acté,
   son drill ouvrant une barre de répartition (le drill à deux
   étages). La fiche chart.pie complétée.
+- **2026-08-14 (suite 18)** — **L'épaisseur et les angles (D520)** :
+  thickness: sur donut/quarter ; les angles de quarter au crochet aux
+  bornes (quarter[-90..90] en proposition) — l'hémicycle de
+  l'assemblée nationale en usage fondateur.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -616,6 +616,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D535 | **`size` aux surfaces, la pile des surimpressions** (amende D454/D534) : « size me convient mieux pour les 2 usages — un form ou une liste apparaissent en surimpression par rapport aux actions antécédentes cumulées » — toute surface s'ouvre au-dessus de la pile ; le couple D484 demeure au grain du champ. | Le dimension: du formulaire (D454) devient size:. Voir §3.2c. |
 | D536 | **La propriété `style:` définie** : « par défaut, le style global de l'application ; prévoyons une propriété style qui regroupe la fonte, la taille et sa mise en forme » — le thème d'instance en défaut, la surcharge à la cascade D461. | `style: { font:, size:, format: [bold…] }` en proposition (le size intérieur = la police — D458 départage). Voir §3.2c. |
 | D537 | **Le résumé précisé** : « le 1-1 affiche le title **ou l'image** si elle est définie » (le visage D386) ; petit par principe confirmé ; « plusieurs sections (pour mêler des affichages horizontaux et verticaux) — pas plusieurs pages, ni plusieurs tabs ». | L'organisateur D489–D491 dans le résumé ; D201 confirmé. Voir §3.2c. |
+| D538 | **Le graphique au résumé** : « un summary peut contenir un kpi ou un chart — à condition que son affichage reste modeste » (D243 réutilisable, la modestie D201). | `chart[<nom>]` en items en proposition (la famille des adresses D460/D483/D511). Voir §3.2c. |
 
 ---
 
@@ -3972,6 +3973,14 @@ plusieurs tabs. »** La restriction du résumé se précise : **plusieurs
 sections** — l'organisateur et ses layouts (D489–D491) mêlent
 l'horizontal et le vertical — mais **l'unique page et jamais
 d'onglets** (D201 confirmé).
+
+**Le graphique au résumé (D538).** **« Un summary peut contenir un
+kpi ou un chart — à condition que son affichage reste modeste. »**
+Les graphiques réutilisables (D243) entrent au résumé, la modestie en
+condition (le petit par principe D201 s'étend à l'embarqué).
+*(L'écriture en proposition : **`chart[<nom>]`** en items — la
+famille des adresses, l'écho de `field[<nom>]` D460,
+`operation[<nom>]` D511 et `template[<nom>]` D483.)*
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11047,3 +11056,7 @@ avant la synthèse Q16).
   affiche le title ou l'image (D386) ; plusieurs sections pour mêler
   l'horizontal et le vertical — pas plusieurs pages ni tabs. La fiche
   summary ajustée.
+- **2026-08-14 (suite 43)** — **Le graphique au résumé (D538)** :
+  « un kpi ou un chart, à condition que son affichage reste
+  modeste » — chart[<nom>] en items en proposition (la famille des
+  adresses).

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -633,6 +633,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D552 | **La séparation tabs/wizard** (amende D504, rend D551 caduque) : « je valide la séparation — ça confirme mon ressenti » — le mode wizard quitte tabs (restent top/bottom/left/right), le wizard garde steps/step et sa mécanique, le chemin D505 à lui seul ; deux objets, une parenté visuelle. | La transactionnalité n'est pas un habillage ; if:/operation: orphelines sur un tab libre ; le mot fait la chose. Voir §3.2c. |
 | D553 | **Le contexte empilé de l'opération** : « le contexte ne représente pas seulement les informations de l'appel en cours mais l'ensemble des contextes qui se sont empilés jusqu'à l'usage de l'opération » — la pile des contextes, le pendant de D535 ; « l'origine de l'appel » (D455) = la pile entière. | Voir §3.2c. |
 | D554 | **Le dashboard aux deux auteurs** (unifie D204/D247) : « le dashboard est à la charge du technicien — un panel accessible depuis un menu ou une page d'accueil ; le pool est un dashboard personnalisable à l'utilisateur en piochant dans les widgets disponibles » — le même objet, deux auteurs. | La vérification : D204/D247 confirment. Voir §3.2c. |
+| D555 | **Le squelette de dashboard** (précise D554) : « le technicien décrit un ou plusieurs squelettes — avec des widgets contraints et des widgets libres » ; l'accueil composé = le squelette entièrement libre. | L'item `free` (répétable) en proposition. Voir §3.2c. |
 
 ---
 
@@ -4169,6 +4170,15 @@ l'utilisateur en piochant dans les widgets disponibles. »** — **la
 page d'accueil composée est un dashboard dont l'utilisateur est
 l'auteur** : le même objet, deux auteurs — le technicien déclare le
 panel, l'utilisateur compose le sien du pool.
+
+**Le squelette de dashboard (D555 — précise D554).** **« Le
+technicien décrit donc un ou plusieurs squelettes de dashboards —
+avec des widgets contraints et des widgets libres. »** Le squelette :
+**les widgets contraints** (fixés par le technicien, non retirables)
+et **les emplacements libres** — l'utilisateur y pioche du pool
+(D247). *(L'écriture en proposition : l'item **`free`** —
+l'emplacement libre, répétable.)* La page d'accueil composée (D554)
+devient le cas limite : **le squelette entièrement libre.**
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11349,3 +11359,7 @@ avant la synthèse Q16).
   D204/D247 mot pour mot ; l'unification actée : la page d'accueil
   composée est un dashboard dont l'utilisateur est l'auteur — le
   même objet, deux auteurs. La fiche ajustée.
+- **2026-08-14 (suite 66)** — **Le squelette de dashboard (D555)** :
+  les widgets contraints et les emplacements libres (l'item free en
+  proposition) ; l'accueil = le squelette entièrement libre. La
+  fiche complétée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -605,6 +605,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D524 | **L'orientation du combiné** : « axis: left \| right, ou bottom \| up, pour une représentation en ligne contre une représentation en colonne » — la paire d'axes dit l'orientation, homogène par construction. | La virgule « up »/« top » (D504) signalée. Voir §3.2c. |
 | D525 | **`top` harmonisé** (amende D524) : « j'harmonise en effet avec top » — `axis: bottom \| top`, le vocabulaire unique des bords avec les tabs (D504). | Voir §3.2c. |
 | D526 | **L'icône aux seuils** : « je souhaite aussi pouvoir associer éventuellement une icône — cas d'un feu tricolore » — les seuils portent la couleur (D467) et/ou l'icône. | `icons:` en proposition (la mécanique D467 dupliquée ; la collision avec la feuille notée — D458) ; la liaison `icon:` à la table D495. Voir §3.2c. |
+| D527 | **L'organisation du kpi** : « mis en valeur avec un style différent de la feuille » ; « l'organisation se découpe en 4 » — la position du label (haut/gauche/bas/droite), l'icône au bord opposé. | `layout: top \| left \| bottom \| right` en proposition (défaut top ; la collision avec D490 notée). Voir §3.2c. |
 
 ---
 
@@ -3839,6 +3840,18 @@ de `colors:` dupliquée, `{ 0: red_light.svg, 50: orange_light.svg,
 le contexte départage (D458) ; et la table d'entité (D495) gagne la
 liaison `icon:` en option.)* Vaut où les seuils valent (D467) — le
 `kpi` en usage premier.
+
+**L'organisation du kpi (D527).** **« Un kpi sera mis en valeur avec
+un style différent de la feuille que nous avons déjà vue »** — le
+chiffre-clé s'affiche en exergue, jamais comme un champ. Et
+**« l'organisation se découpe en 4 : le label en haut - l'icône
+dessous, le label à gauche - l'icône à droite, le label en bas -
+l'icône dessus, le label à droite - l'icône à gauche »** — la position
+du label, **l'icône au bord opposé**. *(L'écriture en proposition :
+`layout: top | left | bottom | right` — la position du label, les
+bords du vocabulaire unique (D525) ; défaut `top` — le premier cité ;
+la collision avec le `layout:` des sections (D490) notée, les valeurs
+départagent — D458.)*
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10838,3 +10851,7 @@ avant la synthèse Q16).
   feu tricolore » — icons: en proposition (la mécanique D467
   dupliquée, la collision avec la feuille notée), la liaison icon: à
   la table D495. La fiche kpi complétée.
+- **2026-08-14 (suite 27)** — **L'organisation du kpi (D527)** : le
+  style en exergue (distinct de la feuille) ; les 4 organisations —
+  la position du label, l'icône au bord opposé ; layout: top|left|
+  bottom|right en proposition (défaut top).

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -10581,3 +10581,8 @@ avant la synthèse Q16).
   dry-run D234) ; le message de confirmation au gabarit
   (validate: { message: } en proposition). La fiche operation
   écrite, en attente de validation.
+- **2026-08-14 (suite 8)** — **La fiche `operation` validée** (« je
+  valide ») — validate: { message: <gabarit> } et les variables de la
+  pré-exécution actés. **La famille des actes est soldée** (une fiche
+  unique — l'habitat fait le visage). Restent : les graphiques
+  (chart/kpi/pivot — Q53) et les surfaces.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -623,6 +623,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D542 | **`qrcode` et `barcode` fichés** (répare un manque) : décidés (D252/D300 — les composants de sortie) mais absents de l'inventaire des fiches — les deux feuilles jumelles ajoutées, la fiche commune. | `barcode[ean13\|code128…]` au crochet en proposition (défaut code128) ; le scan hors D300. Voir §3.2c. |
 | D543 | **Le `size` des jumeaux** : le qrcode — « la taille unique pour les côtés » (`size: 120px`, le carré) ; le code-barres — « largeur × hauteur » (la grammaire D533). | Voir §3.2c. |
 | D544 | **Les deux modes du champ encodé** (précise D300/D543) : « la saisie en mode texte et l'affichage en mode graphique — la saisie peut nécessiter une size différente de l'affichage ». | `size: { input:, display: }` en proposition (la forme courte = l'affichage seul). Voir §3.2c. |
+| D545 | **La valeur sous les barres** : « l'affichage du code-barres peut nécessiter l'affichage de la valeur de la référence sous le code-barres » — l'humain sous la machine. | `labels: true` en proposition (l'écho D516, défaut false). Voir §3.2c. |
 
 ---
 
@@ -4044,6 +4045,13 @@ texte — la taille D366, le masque), **l'affichage est le graphique**
 — et chacun peut porter sa taille. *(L'écriture en proposition :
 `size: { input: …, display: … }` — la forme courte `size: 120px` =
 l'affichage seul, la saisie restant au régime du texte.)*
+
+**La valeur sous les barres (D545).** **« L'affichage du code-barres
+peut nécessiter l'affichage de la valeur de la référence sous le
+code-barres. »** La valeur lisible à l'humain, sous la valeur lisible
+à la machine — l'usage des étiquettes EAN. *(L'écriture en
+proposition : `labels: true` — l'écho D516, la valeur au format du
+champ ; défaut `false`.)*
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11157,3 +11165,6 @@ avant la synthèse Q16).
   (D544)** : la saisie en mode texte (le régime du champ), l'affichage
   en mode graphique — chacun sa taille ; size: { input:, display: }
   en proposition.
+- **2026-08-14 (suite 52)** — **La valeur sous les barres (D545)** :
+  labels: true en proposition (l'écho D516, défaut false) — l'humain
+  sous la machine.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -611,6 +611,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D530 | **Les appels du geste et les exports** : « add, update or delete pour préciser le formulaire/widget à appeler » (les défauts : le formulaire par défaut D438, les gestes D446) ; « exports: permet de préciser les différents exports ou générations de documents ». | `exports: [ csv, excel[modèle], template[gabarit] ]` en proposition. Voir §3.2c. |
 | D531 | **Les actions et l'anatomie de la liste** : `actions:` (l'opération porte son icône, surchargeable) ; « une liste est comme pages » — le header (titre, colonnes, filtres, l'icône-menu des exports, les icônes add/update/delete + actions à icône), la zone page (le tableau), le footer (le sous-total ou un gabarit, les boutons des actions sans icône). | L'icône trie : header ; sans icône : bouton du pied. `{count}` au gabarit en proposition. Voir §3.2c. |
 | D532 | **`size:` et `screen:` sur la liste** : « comme la form — size pour marquer la zone de couverture de l'écran, screen pour indiquer sur quel support la liste a été définie et/ou autorisée à s'afficher ». | La cohérence D484/D503 et D450. Voir §3.2c. |
+| D533 | **La grammaire de `size:`** : « 75% → 75 % de l'écran avec centrage ; 90% 50% → la longueur et la hauteur ; ou 1000px 320px en pixels » — une valeur centrée, deux valeurs largeur puis hauteur, % ou px. | Vaut partout où size s'écrit (D484). Voir §3.2c. |
 
 ---
 
@@ -3915,6 +3916,14 @@ support la liste a été définie et/ou autorisée à s'afficher. »** La
 cohérence s'étend : `size` = la couverture à l'affichage (D484/D503),
 `screen` = le support de conception **et** l'autorisation (D450 — le
 tableau `[pc paysage]` en défaut).
+
+**La grammaire de `size:` (D533).** **« `size: 75%` → 75 % de l'écran
+avec centrage ; `size: 90% 50%` → 90 % de la longueur de l'écran et
+50 % de la hauteur ; ou `1000px 320px` pour un dimensionnement en
+pixels. »** Une valeur = la part de l'écran, **centrée** ; deux
+valeurs = **la largeur puis la hauteur** ; l'unité : `%` ou `px`. La
+grammaire vaut **partout où `size` s'écrit** (D484 — la carte, les
+sections, le kpi, la liste…).
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10958,3 +10967,6 @@ avant la synthèse Q16).
 - **2026-08-14 (suite 35)** — **size et screen sur la liste (D532)** :
   la couverture de l'écran (D484/D503) et le support de conception
   et/ou d'autorisation (D450). La fiche complétée.
+- **2026-08-14 (suite 36)** — **La grammaire de size (D533)** : une
+  valeur = la part de l'écran centrée ; deux valeurs = largeur puis
+  hauteur ; % ou px — partout où size s'écrit (D484).

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -601,6 +601,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D520 | **L'épaisseur et les angles** (complète D519) : « sur donut, l'épaisseur ; sur quarter, l'angle de départ, de fin et l'épaisseur — représenter l'assemblée nationale de la gauche vers la droite ». | `thickness:` et les angles aux bornes (`quarter[-90..90]`) en proposition ; l'hémicycle fondateur. Voir §3.2c. |
 | D521 | **Le graphique, le tableau, ou les deux** (au socle des charts) : « les charts doivent se présenter soit en graphique, soit sous forme d'un tableau — pour avoir une vue sur les différentes valeurs directement — ou les deux ». | L'écho des tableaux de valeurs D244 ; `display: graph \| table \| both` en proposition (défaut graph). Voir §3.2c. |
 | D522 | **Le nuage de points** : un point par enregistrement (le visage D386) ; « les axes se déclinent via des seuils qui ne se chevauchent pas » — la concentration/dispersion, **et la catégorisation** : « un MoSCoW en s'appuyant sur 2 critères, les gains/bénéfices de l'effort ». | `thresholds:` à l'axe riche + `zones:` (title/color, les bornes D366) en proposition ; le clic sur une zone → la liste. Voir §3.2c. |
+| D523 | **La matrice adressée** (simplifie D522) : « l'axe définit min, max et threshold ; les zones définissent les positions dans la matrice créée — plutôt que x et y, `zone: [1,1]` » — plus aucune borne répétée. | Convention `[colonne, ligne]` depuis l'origine (bas-gauche) en proposition. Voir §3.2c. |
 
 ---
 
@@ -3800,6 +3801,15 @@ la forme riche de l'axe — la liste croissante, non chevauchante par
 construction ; **`zones:`** — la zone au croisement des bandes,
 `x: 0..50` aux bornes D366, `title:` et `color:` ; le clic sur une
 zone → la liste de ses éléments, l'écho D519.)*
+
+**La matrice adressée (D523 — simplifie D522).** **« Je vois une
+redondance entre threshold et le découpage des zones. Nous pouvons
+simplifier : l'axe définit min, max et threshold. Les zones
+définissent les positions dans la matrice créée — plutôt que x et y,
+`zone: [1,1]`, `title: { … }`. »** Les seuils font la matrice une
+fois ; la zone s'y **adresse** par sa position — plus aucune borne
+répétée. *(La convention en proposition : `[colonne, ligne]` depuis
+l'origine des axes — `[1,1]` en bas à gauche.)*
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10776,3 +10786,7 @@ avant la synthèse Q16).
   d'axe non chevauchants, les zones aux croisements — la
   catégorisation (MoSCoW, effort/bénéfice) ; thresholds:/zones: en
   proposition. La fiche chart.scatter écrite.
+- **2026-08-14 (suite 21)** — **La matrice adressée (D523)** : la
+  redondance effacée — l'axe porte min/max/threshold, la zone
+  s'adresse (zone: [1,1] + title) ; la convention [colonne, ligne]
+  depuis l'origine en proposition. La fiche simplifiée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -632,6 +632,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D551 | **Un seul wizard** : « tout ce que nous venons de voir avec wizard doit être également porté par tabs[wizard]… car cela doit être le même objet » — la surface et le conteneur, un même composant (l'écho D486) ; seule change la porte d'entrée. | Les fiches wizard et tabs liées. Voir §3.2c. |
 | D552 | **La séparation tabs/wizard** (amende D504, rend D551 caduque) : « je valide la séparation — ça confirme mon ressenti » — le mode wizard quitte tabs (restent top/bottom/left/right), le wizard garde steps/step et sa mécanique, le chemin D505 à lui seul ; deux objets, une parenté visuelle. | La transactionnalité n'est pas un habillage ; if:/operation: orphelines sur un tab libre ; le mot fait la chose. Voir §3.2c. |
 | D553 | **Le contexte empilé de l'opération** : « le contexte ne représente pas seulement les informations de l'appel en cours mais l'ensemble des contextes qui se sont empilés jusqu'à l'usage de l'opération » — la pile des contextes, le pendant de D535 ; « l'origine de l'appel » (D455) = la pile entière. | Voir §3.2c. |
+| D554 | **Le dashboard aux deux auteurs** (unifie D204/D247) : « le dashboard est à la charge du technicien — un panel accessible depuis un menu ou une page d'accueil ; le pool est un dashboard personnalisable à l'utilisateur en piochant dans les widgets disponibles » — le même objet, deux auteurs. | La vérification : D204/D247 confirment. Voir §3.2c. |
 
 ---
 
@@ -4155,6 +4156,19 @@ voit tout ce qui s'est empilé : le périmètre de la liste,
 l'enregistrement du formulaire, le transitoire du wizard.
 « L'origine de l'appel » de D455 se relit : **la pile entière, pas le
 dernier maillon.**
+
+**Le dashboard aux deux auteurs (D554 — unifie D204/D247).** La
+vérification demandée (« est-ce bien cela ? ») : oui — D204 («
+l'utilisateur sélectionne une entrée du menu ou laisse vierge, et
+choisit les widgets ») et D247 (« le pool : les widgets de ses
+modules, sous sa confidentialité ») disent exactement cela. Et la
+formulation de l'auteur unifie : **« le dashboard est à la charge du
+technicien — un panel de dashboards accessibles depuis un menu ou une
+page d'accueil. Le pool est un dashboard personnalisable à
+l'utilisateur en piochant dans les widgets disponibles. »** — **la
+page d'accueil composée est un dashboard dont l'utilisateur est
+l'auteur** : le même objet, deux auteurs — le technicien déclare le
+panel, l'utilisateur compose le sien du pool.
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11330,3 +11344,8 @@ avant la synthèse Q16).
   widgets assemblés ; en proposition : le bloc dashboards: au module,
   refresh: static|live|every[…] (D434), widget[<entité>.<nom>]
   (la famille des adresses).
+- **2026-08-14 (suite 65)** — **Le dashboard aux deux auteurs
+  (D554)** : la vérification (« est-ce bien cela ? ») — oui,
+  D204/D247 mot pour mot ; l'unification actée : la page d'accueil
+  composée est un dashboard dont l'utilisateur est l'auteur — le
+  même objet, deux auteurs. La fiche ajustée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -620,6 +620,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D539 | **La troisième assise du chart** (élargit D517) : « elle s'appuie sur une entité ou un champ de type list of ou association with » — le champ-collection : le graphique des éléments liés à l'enregistrement du contexte. | `on: <champ>` en proposition. Voir §3.2c. |
 | D540 | **Le chart, feuille du formulaire** : « un form peut donc avoir un composant chart comme feuille — nous le faisons entrer de fait dans summary » — `chart[<nom>]` en item du form, le résumé l'héritant (la modestie D538). | Confirme D243/D538. Voir §3.2c. |
 | D541 | **La tendance du kpi** (note pour plus tard) : « en exploitant l'historique d'une entité, nous pourrions présenter la tendance » — la valeur rejouée aux instants passés (D411/D172) ; le détail différé. | La frontière avec D245 à confirmer au moment venu. Voir §3.2c. |
+| D542 | **`qrcode` et `barcode` fichés** (répare un manque) : décidés (D252/D300 — les composants de sortie) mais absents de l'inventaire des fiches — les deux feuilles jumelles ajoutées, la fiche commune. | `barcode[ean13\|code128…]` au crochet en proposition (défaut code128) ; le scan hors D300. Voir §3.2c. |
 
 ---
 
@@ -4011,6 +4012,20 @@ l'historisation (D411) et l'API temporelle « au plus proche ≤ date »
 arbitrer au moment venu : la frontière avec D245 — « pas de
 comparaison dans le socle » ; la tendance issue de l'historique n'est
 pas la comparaison de périodes, la lecture à confirmer.)*
+
+**Le QR code et le code-barres fichés (D542 — répare un manque).**
+**« Avant de reprendre, avons-nous décrit les qrcode et code
+barres ? »** La vérification : décidés — D252 (l'étiquette imprimée
+du serveur) et D300 (les composants de **sortie**, « ils rendent la
+valeur d'un champ », clôt Q56) — mais jamais fichés : l'inventaire
+des feuilles les avait manqués. Réparé : **`qrcode` et `barcode`**,
+deux feuilles jumelles à la fiche commune — la valeur convertie en
+texte (D369) rendue lisible à la machine ; l'écran en lecture, le
+PDF/l'étiquette en usage premier, Excel = la valeur source. *(En
+proposition : le format du code-barres au crochet —
+`barcode[ean13]`, `barcode[code128]` — le défaut `code128` ; la
+saisie par scan reste hors D300 — les composants sont de sortie, la
+question du scan pour plus tard si besoin.)*
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11113,3 +11128,7 @@ avant la synthèse Q16).
   plus tard)** : « en exploitant l'historique d'une entité, nous
   pourrions présenter la tendance » — la piste consignée
   (D411/D172), le détail différé, la frontière avec D245 à confirmer.
+- **2026-08-14 (suite 49)** — **qrcode et barcode fichés (D542)** :
+  la question de l'auteur relève le manque — décidés (D252/D300)
+  mais jamais fichés ; la fiche commune écrite, l'inventaire et la
+  synthèse complétés ; le format au crochet en proposition.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -10890,3 +10890,10 @@ avant la synthèse Q16).
   complet (les feuilles, les conteneurs, les actes, les graphiques) ;
   **ne restent que les surfaces — la passe réservée : la construction
   des surfaces pour une entité.**
+- **2026-08-14 (suite 32)** — **La passe des surfaces ouverte** : la
+  méthode validée (« la méthode me convient, entrons par la liste ») —
+  le fil conducteur sales.order, les surfaces dans l'ordre d'usage
+  (liste → formulaire → résumé → widgets → wizard → templates →
+  dashboard), la fiche + l'exemple + la validation à chaque étape. La
+  fiche de la liste-surface écrite (le visage déclaré du composant
+  unique D486).

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -635,6 +635,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D554 | **Le dashboard aux deux auteurs** (unifie D204/D247) : « le dashboard est à la charge du technicien — un panel accessible depuis un menu ou une page d'accueil ; le pool est un dashboard personnalisable à l'utilisateur en piochant dans les widgets disponibles » — le même objet, deux auteurs. | La vérification : D204/D247 confirment. Voir §3.2c. |
 | D555 | **Le squelette de dashboard** (précise D554) : « le technicien décrit un ou plusieurs squelettes — avec des widgets contraints et des widgets libres » ; l'accueil composé = le squelette entièrement libre. | L'item `free` (répétable) en proposition. Voir §3.2c. |
 | D556 | **L'emplacement `_` et l'icône du choix** (amende D555) : « un widget interchangeable doit faire apparaître un icône qui permette de choisir un widget disponible selon son propre catalogue ou par sa libération » ; « "_" me parle plus que "free" — free pouvant être lui-même un nom de widget ». | L'item `_` acté ; la collision évitée par construction. Voir §3.2c. |
+| D557 | **L'accueil au module actif** : « une page d'accueil fait référence à un dashboard selon le module activé » — le module actif fournit son tableau de bord. | Complète D554–D556. Voir §3.2c. |
 
 ---
 
@@ -4191,6 +4192,12 @@ D247), ou un widget rendu disponible par la libération d'un autre
 emplacement. Et l'écriture est actée : **« "_" me parle plus que
 "free" — free pouvant être lui-même un nom de widget »** — l'item
 **`_`**, la collision évitée par construction.
+
+**L'accueil au module actif (D557).** **« Une page d'accueil fait
+référence à un dashboard selon le module activé. »** L'accueil n'est
+pas un tableau figé : **le module actif fournit son dashboard** — en
+changeant de module, l'utilisateur change de tableau de bord (le
+squelette du technicien, ses emplacements `_` composés — D554–D556).
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11379,3 +11386,6 @@ avant la synthèse Q16).
   choix sur le widget interchangeable (le catalogue propre ou la
   libération) ; « _ » acté à la place de free (la collision évitée).
   La fiche ajustée.
+- **2026-08-14 (suite 68)** — **L'accueil au module actif (D557)** :
+  « une page d'accueil fait référence à un dashboard selon le module
+  activé » — le changement de module change le tableau de bord.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -615,6 +615,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D534 | **La confusion levée** (clarifie D532) : « j'ai introduit une confusion entre dimension et size » — la doctrine D484 départage : le formulaire s'ouvre à l'appel → `dimension:` (D454) ; la liste s'affiche → `size:` ; la grammaire D533 vaut pour les deux. | Voir §3.2c. |
 | D535 | **`size` aux surfaces, la pile des surimpressions** (amende D454/D534) : « size me convient mieux pour les 2 usages — un form ou une liste apparaissent en surimpression par rapport aux actions antécédentes cumulées » — toute surface s'ouvre au-dessus de la pile ; le couple D484 demeure au grain du champ. | Le dimension: du formulaire (D454) devient size:. Voir §3.2c. |
 | D536 | **La propriété `style:` définie** : « par défaut, le style global de l'application ; prévoyons une propriété style qui regroupe la fonte, la taille et sa mise en forme » — le thème d'instance en défaut, la surcharge à la cascade D461. | `style: { font:, size:, format: [bold…] }` en proposition (le size intérieur = la police — D458 départage). Voir §3.2c. |
+| D537 | **Le résumé précisé** : « le 1-1 affiche le title **ou l'image** si elle est définie » (le visage D386) ; petit par principe confirmé ; « plusieurs sections (pour mêler des affichages horizontaux et verticaux) — pas plusieurs pages, ni plusieurs tabs ». | L'organisateur D489–D491 dans le résumé ; D201 confirmé. Voir §3.2c. |
 
 ---
 
@@ -3961,6 +3962,16 @@ proposition : `style: { font: Roboto, size: 14px, format: [bold,
 italic] }` — le `size` intérieur = la taille de la police, le contexte
 départageant du size d'emprise D535 (D458) ; `format:` parmi bold,
 italic, underline, strike.)*
+
+**Le résumé précisé (D537).** **« Le 1-1 affiche le title ou l'image
+si elle est définie »** — le visage de l'entité (D386) vaut aussi à la
+référence. **« Je confirme : cela doit rester petit par principe.
+Cependant, nous pourrions avoir plusieurs sections (pour mêler des
+affichages horizontaux et verticaux). Pas plusieurs pages, ni
+plusieurs tabs. »** La restriction du résumé se précise : **plusieurs
+sections** — l'organisateur et ses layouts (D489–D491) mêlent
+l'horizontal et le vertical — mais **l'unique page et jamais
+d'onglets** (D201 confirmé).
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11032,3 +11043,7 @@ avant la synthèse Q16).
   restreinte (D201 : les champs sélectionnés, pas d'onglets, petit
   par principe, le défaut n'existe pas), le visage déployé de la
   référence (D215).
+- **2026-08-14 (suite 42)** — **Le résumé précisé (D537)** : le 1-1
+  affiche le title ou l'image (D386) ; plusieurs sections pour mêler
+  l'horizontal et le vertical — pas plusieurs pages ni tabs. La fiche
+  summary ajustée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -11402,3 +11402,11 @@ avant la synthèse Q16).
   (D558)** : « la limiter à un dashboard m'embête » — la liste, le
   dashboard (du module actif — D557) ou la page vide ; la lettre de
   D204 retrouvée.
+- **2026-08-14 (suite 70)** — **La fiche `dashboard` validée** (« je
+  valide dashboard »). La dernière surface : la fiche `template`
+  écrite sur le matériau Q57 (D250–D254) — le formulaire en lecture
+  seule + la dimension de page, l'entité contexte, un gabarit par
+  langue, les quatre portes (l'effet document, le viewer, les
+  exports, l'impression serveur) ; le rendez-vous Q55 atteint
+  (paragraph/picture/viewer à étoffer) ; en proposition : paper:,
+  l'écriture du gabarit par langue.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -629,6 +629,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D548 | **L'anatomie du wizard** : « un header et un footer ; le fil d'Ariane en bas ou en haut de la zone ; une dimension (size) surchargeable si le wizard s'inclut dans un formulaire ». | `mode: top \| bottom` en proposition (D525) ; l'écho pages D507 ; le plus proche l'emporte (D461). Voir §3.2c. |
 | D549 | **Les arbitrages du wizard** (amende D548) : « size est optionnel — sans valeur, l'espace disponible ; depuis un menu, tout l'écran » ; « plutôt que mode, je préfère **breadcrumb: none \| top \| bottom** ». | Défaut top (l'esprit D504) ; none masque le fil. Voir §3.2c. |
 | D550 | **L'aide à la décision au parcours** : « nous pouvons inclure des charts, des kpi ou des pivots pour apporter une aide à la décision » — les graphiques aux steps (`chart[<nom>]` — D540). | Voir §3.2c. |
+| D551 | **Un seul wizard** : « tout ce que nous venons de voir avec wizard doit être également porté par tabs[wizard]… car cela doit être le même objet » — la surface et le conteneur, un même composant (l'écho D486) ; seule change la porte d'entrée. | Les fiches wizard et tabs liées. Voir §3.2c. |
 
 ---
 
@@ -4114,6 +4115,17 @@ aide à la décision. »** Les graphiques entrent aux steps
 (`chart[<nom>]` — D540, la famille entière) : le chiffre, la courbe
 ou le croisé éclairent le choix avant le passage — l'aide à la
 décision au fil du parcours guidé.
+
+**Un seul wizard (D551).** **« Tout ce que nous venons de voir avec
+wizard doit être également porté par `tabs[wizard]`… car cela doit
+être le même objet. »** La ligne de D486 (« un seul list ») se
+répète : **la surface `wizard` (`gui: wizards:`) et le conteneur
+`tabs[wizard]` sont le même composant** — les steps-tabs, l'`if:` et
+l'`operation:` d'étape (D546), la chaîne de pré-exécutions et la
+transformation finale (D547), le cliquet, le header/footer (D548), le
+`breadcrumb:` et le `size:` optionnel (D549), les graphiques (D550) —
+tout vaut des deux côtés ; seule change la porte d'entrée (le menu ou
+l'emboîtement).
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11262,3 +11274,7 @@ avant la synthèse Q16).
 - **2026-08-14 (suite 59)** — **L'aide à la décision (D550)** : les
   charts, kpi et pivots aux steps du wizard (chart[<nom>] — D540) —
   la 550e décision.
+- **2026-08-14 (suite 60)** — **Un seul wizard (D551)** : « cela doit
+  être le même objet » — la surface wizard et tabs[wizard], un même
+  composant (l'écho D486), tout D546–D550 valant des deux côtés. Les
+  fiches liées.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -619,6 +619,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D538 | **Le graphique au résumé** : « un summary peut contenir un kpi ou un chart — à condition que son affichage reste modeste » (D243 réutilisable, la modestie D201). | `chart[<nom>]` en items en proposition (la famille des adresses D460/D483/D511). Voir §3.2c. |
 | D539 | **La troisième assise du chart** (élargit D517) : « elle s'appuie sur une entité ou un champ de type list of ou association with » — le champ-collection : le graphique des éléments liés à l'enregistrement du contexte. | `on: <champ>` en proposition. Voir §3.2c. |
 | D540 | **Le chart, feuille du formulaire** : « un form peut donc avoir un composant chart comme feuille — nous le faisons entrer de fait dans summary » — `chart[<nom>]` en item du form, le résumé l'héritant (la modestie D538). | Confirme D243/D538. Voir §3.2c. |
+| D541 | **La tendance du kpi** (note pour plus tard) : « en exploitant l'historique d'une entité, nous pourrions présenter la tendance » — la valeur rejouée aux instants passés (D411/D172) ; le détail différé. | La frontière avec D245 à confirmer au moment venu. Voir §3.2c. |
 
 ---
 
@@ -4000,6 +4001,16 @@ fait dans summary. »** La conséquence est actée : `chart[<nom>]` est
 un item du formulaire au même titre que les feuilles (D243 tenait la
 promesse) — et le résumé, restriction du formulaire (D201), **en
 hérite de fait** — la modestie en condition (D538).
+
+**La tendance du kpi (D541 — la note pour plus tard).** **« Un kpi
+peut avoir une notion d'historique. En exploitant l'historique d'une
+entité, nous pourrions présenter la tendance. »** La piste consignée,
+le détail différé : la valeur du kpi rejouée aux instants passés —
+l'historisation (D411) et l'API temporelle « au plus proche ≤ date »
+(D172) savent déjà le faire — la tendance en regard du chiffre. *(À
+arbitrer au moment venu : la frontière avec D245 — « pas de
+comparaison dans le socle » ; la tendance issue de l'historique n'est
+pas la comparaison de périodes, la lecture à confirmer.)*
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11098,3 +11109,7 @@ avant la synthèse Q16).
   surfaces** : list, form, summary, widget validées (D530–D540) ;
   restent wizard, dashboard, template — puis la signature des nœuds,
   Q60, les domaines 5–8.
+- **2026-08-14 (suite 48)** — **La tendance du kpi (D541, note pour
+  plus tard)** : « en exploitant l'historique d'une entité, nous
+  pourrions présenter la tendance » — la piste consignée
+  (D411/D172), le détail différé, la frontière avec D245 à confirmer.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -10818,3 +10818,7 @@ avant la synthèse Q16).
 - **2026-08-14 (suite 24)** — **top harmonisé (D525)** : « j'harmonise
   en effet avec top » — axis: bottom|top, les bords nommés d'un seul
   vocabulaire (D504).
+- **2026-08-14 (suite 25)** — **La fiche `chart.combo` validée** (« je
+  valide chart.combo »). Suivante : `kpi` — le chiffre-clé (value:
+  sans axe, colors: par seuils D467, drill D242, pas de comparaison
+  au socle D245 — le hook).

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -592,6 +592,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D511 | **L'acte et les deux modes** : « operation[<nom>] pour être en phase avec les fields » ; « une opération doit avoir 2 modes — la pré-exécution identifie les modifications à apporter (les factures à créer ; l'import : ajoutées/modifiées/non modifiées/supprimées) » ; le message de confirmation au gabarit nourri de la pré-exécution. | Généralise D234 et l'exécution à blanc ; `validate: { message: }` en proposition (étend D431). Voir §3.2c. |
 | D512 | **La famille `chart.*`** actée (l'écho des pickers, la note D470) : `chart.line`, `chart.bars`, `chart.pie`, `chart.combo` — et « j'ajouterais également **le nuage de points** » : `chart.scatter` ; `kpi` et `pivot` à part, la jauge restant la feuille `gauge`. | Le hook étend (`chart.radar`…) — D239. Voir §3.2c. |
 | D513 | **La carte des collections** : « le composant doit pouvoir s'adapter pour une coordonnée ou une liste de coordonnées dont des lignes sont possibles ou pas » — les marqueurs multiples, le tracé dans l'ordre de la collection. | Rien n'était consigné (vérifié) ; `lines: true \| false` en proposition (défaut false). Voir §3.2c. |
+| D514 | **La frontière de la route** (complète D513) : les lieux d'un produit (sans relier) / le parcours d'un commercial (relié) ; le socle relie au trait droit — **« le tracé de la route, je préfère le laisser aux hooks »** (les abonnements aux outils annexes). | Le patron du géocodage D294 — candidats open source auto-hébergeables : OSRM, Valhalla (Q7). Voir §3.2c. |
 
 ---
 
@@ -3687,6 +3688,19 @@ coordonnées** (`list of geolocation`, l'association aux coordonnées) =
 le tracé reliant les points dans l'ordre de la collection (l'itinéraire,
 la tournée) — **possibles ou pas**. *(L'écriture en proposition :
 `lines: true | false` — défaut `false`, les marqueurs seuls.)*
+
+**Les deux usages et la frontière de la route (D514 — complète
+D513).** Les usages posés : **« présenter tous les lieux de commandes
+pour un produit (pas besoin de relier les points), ou représenter le
+parcours d'un commercial (relier les points entre eux) »**. Et la
+frontière : **« nous pourrions également prévoir le tracé de la route,
+mais cela nécessite de prendre des abonnements à des outils annexes —
+je préfère le laisser aux hooks. »** Le socle relie **au trait droit**
+(à vol d'oiseau — l'écho D391) sans aucune dépendance ; **le tracé de
+la route = un hook/connecteur** — le patron exact du géocodage
+(D294) : les services payants existent (Google, Mapbox), et des
+candidats open source auto-hébergeables aussi (**OSRM**, **Valhalla**
+— sur les données OpenStreetMap) ; le choix à re-vérifier en Q7.
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10615,3 +10629,8 @@ avant la synthèse Q16).
   une coordonnée ou une liste de coordonnées, les lignes possibles ou
   pas (rien n'était consigné — la fiche map complétée ; lines: en
   proposition). Première fiche à venir : chart.line.
+- **2026-08-14 (suite 10)** — **La frontière de la route (D514)** :
+  les deux usages (les lieux sans relier, le parcours relié) ; le
+  socle au trait droit, « le tracé de la route aux hooks » — le
+  patron du géocodage (D294), OSRM/Valhalla en candidats
+  auto-hébergeables (Q7).

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -607,6 +607,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D526 | **L'icône aux seuils** : « je souhaite aussi pouvoir associer éventuellement une icône — cas d'un feu tricolore » — les seuils portent la couleur (D467) et/ou l'icône. | `icons:` en proposition (la mécanique D467 dupliquée ; la collision avec la feuille notée — D458) ; la liaison `icon:` à la table D495. Voir §3.2c. |
 | D527 | **L'organisation du kpi** : « mis en valeur avec un style différent de la feuille » ; « l'organisation se découpe en 4 » — la position du label (haut/gauche/bas/droite), l'icône au bord opposé. | `layout: top \| left \| bottom \| right` en proposition (défaut top ; la collision avec D490 notée). Voir §3.2c. |
 | D528 | **Le tri du croisé sur la valeur** : « visualiser les plus gros CA » — les lignes par la valeur agrégée, chaque niveau du groupement par son sous-total ; le défaut = l'ordre naturel du champ. | `sort: -value` en proposition (le signe D441). Voir §3.2c. |
+| D529 | **Le tri aux trois clés** (élargit D528) : « le tri peut s'appuyer sur les rows, les columns ou la value » — les signes et cascades D441 (`sort: { seller: -value, date: + }`). | Voir §3.2c. |
 
 ---
 
@@ -3861,6 +3862,12 @@ dans un groupement hiérarchique, **chaque niveau se trie par son
 sous-total** (les commerciaux par leur CA, leurs clients par le
 leur). Le défaut demeure l'ordre naturel du champ. *(L'écriture en
 proposition : `sort: -value` — le signe du tri des listes, D441.)*
+
+**Le tri aux trois clés (D529 — élargit D528).** **« Le tri peut
+s'appuyer sur les rows, les columns ou la value. »** La clé du tri :
+un champ des lignes, un champ des colonnes, ou la valeur — les signes
+et les cascades de D441 valent (`sort: { seller: -value, date: + }` —
+les commerciaux par leur CA décroissant, les mois chronologiques).
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10873,3 +10880,6 @@ avant la synthèse Q16).
   sur la value pour visualiser les plus gros CA » — chaque niveau du
   groupement par son sous-total, sort: -value en proposition (D441).
   La fiche pivot complétée.
+- **2026-08-14 (suite 30)** — **Le tri aux trois clés (D529)** : « le
+  tri peut s'appuyer sur les rows, les columns ou la value » — les
+  signes et cascades D441.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -603,6 +603,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D522 | **Le nuage de points** : un point par enregistrement (le visage D386) ; « les axes se déclinent via des seuils qui ne se chevauchent pas » — la concentration/dispersion, **et la catégorisation** : « un MoSCoW en s'appuyant sur 2 critères, les gains/bénéfices de l'effort ». | `thresholds:` à l'axe riche + `zones:` (title/color, les bornes D366) en proposition ; le clic sur une zone → la liste. Voir §3.2c. |
 | D523 | **La matrice adressée** (simplifie D522) : « l'axe définit min, max et threshold ; les zones définissent les positions dans la matrice créée — plutôt que x et y, `zone: [1,1]` » — plus aucune borne répétée. | Convention `[colonne, ligne]` depuis l'origine (bas-gauche) en proposition. Voir §3.2c. |
 | D524 | **L'orientation du combiné** : « axis: left \| right, ou bottom \| up, pour une représentation en ligne contre une représentation en colonne » — la paire d'axes dit l'orientation, homogène par construction. | La virgule « up »/« top » (D504) signalée. Voir §3.2c. |
+| D525 | **`top` harmonisé** (amende D524) : « j'harmonise en effet avec top » — `axis: bottom \| top`, le vocabulaire unique des bords avec les tabs (D504). | Voir §3.2c. |
 
 ---
 
@@ -3821,6 +3822,11 @@ représentation en ligne. La paire est homogène par construction (les
 deux séries du même régime). *(La virgule de vocabulaire signalée :
 « up » ici, « top » chez les tabs (D504) — l'harmonisation à
 trancher.)*
+
+**L'harmonisation : `top` (D525 — amende D524).** **« J'harmonise en
+effet avec top »** — la paire couchée s'écrit **`bottom | top`**, le
+vocabulaire unique avec les tabs (D504) : top/bottom/left/right
+partout où un bord se nomme.
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10809,3 +10815,6 @@ avant la synthèse Q16).
 - **2026-08-14 (suite 23)** — **L'orientation du combiné (D524)** :
   axis: left|right ou bottom|up — la représentation en colonne ou en
   ligne, la paire homogène ; la virgule up/top (D504) signalée.
+- **2026-08-14 (suite 24)** — **top harmonisé (D525)** : « j'harmonise
+  en effet avec top » — axis: bottom|top, les bords nommés d'un seul
+  vocabulaire (D504).

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -11278,3 +11278,8 @@ avant la synthèse Q16).
   être le même objet » — la surface wizard et tabs[wizard], un même
   composant (l'écho D486), tout D546–D550 valant des deux côtés. Les
   fiches liées.
+- **2026-08-14 (suite 61)** — **La revue tabs/wizard ouverte** :
+  « ça m'embête d'avoir 2 vocabulaires (tabs/steps) pour un même
+  objet — faut-il sortir wizard de tabs, ou au contraire fusionner
+  les 2 ? » — la validation du wizard suspendue, les deux voies
+  posées dans l'échange avec recommandation ; l'arbitrage attendu.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -637,6 +637,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D556 | **L'emplacement `_` et l'icône du choix** (amende D555) : « un widget interchangeable doit faire apparaître un icône qui permette de choisir un widget disponible selon son propre catalogue ou par sa libération » ; « "_" me parle plus que "free" — free pouvant être lui-même un nom de widget ». | L'item `_` acté ; la collision évitée par construction. Voir §3.2c. |
 | D557 | **L'accueil au module actif** : « une page d'accueil fait référence à un dashboard selon le module activé » — le module actif fournit son tableau de bord. | Complète D554–D556. Voir §3.2c. |
 | D558 | **La homepage aux trois pointes** (amende D557) : « la limiter à un dashboard m'embête — la homepage doit pouvoir pointer une liste, un dashboard ou une page vide ». | La lettre de D204 retrouvée ; la composition aux emplacements `_` (D555–D556). Voir §3.2c. |
+| D559 | **Le template précisé** : `margin:` en mm ; « le paragraph peut être un gabarit — le cas d'une lettre » (le publipostage, l'étoffement Q55) ; « la déclinaison par langue se porte sur chaque item » (amende la lecture de D253 — un seul gabarit, les items déclinés). | Voir §3.2c. |
 
 ---
 
@@ -4207,6 +4208,16 @@ L'accueil pointe : **une liste** (l'entrée du menu — la lettre de
 D204 retrouvée), **un dashboard** (celui du module activé — D557), ou
 **la page vide** (D191). La composition personnelle vit désormais aux
 emplacements `_` des squelettes (D555–D556).
+
+**Le template précisé (D559).** Trois apports : **« `margin:` pour
+définir les marges en mm »** ; **« le paragraph peut être un
+gabarit — utilisable dans le cas d'une lettre »** — le publipostage
+naît : le texte fixe (D488) sait porter les variables de
+l'enregistrement (« Cher {customer}, votre commande {number}… ») —
+l'étoffement Q55 commence ; **« la déclinaison par langue se porte
+sur chaque item »** — la lecture de D253 s'amende : **un seul
+gabarit**, ses items déclinés par langue (la mécanique D465), non un
+gabarit entier par langue.
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11410,3 +11421,8 @@ avant la synthèse Q16).
   exports, l'impression serveur) ; le rendez-vous Q55 atteint
   (paragraph/picture/viewer à étoffer) ; en proposition : paper:,
   l'écriture du gabarit par langue.
+- **2026-08-14 (suite 71)** — **Le template précisé (D559)** :
+  margin: en mm ; le paragraph-gabarit (la lettre — l'étoffement Q55
+  commence) ; la déclinaison par langue à chaque item (D253 amendé :
+  un seul gabarit, les items déclinés). Les écarts
+  template/formulaire posés dans l'échange pour revue.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -590,6 +590,8 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D509 | **Le formulaire est un `pages` implicite, `body` disparaît** (amende D449/D455/D490) : « pages est le premier composant d'un formulaire sans avoir besoin de le déclarer ; header et footer sont déjà décrits ; body est à remplacer par page » — et « pas besoin de composants complémentaires » : les conteneurs sont au complet. | La clé `page:` remplace `body:` (30 occurrences balayées) ; le multi-pages à préciser. Voir §3.2c. |
 | D510 | **Le multi-pages en liste** : « le multi-pages se fait à l'aide d'une liste d'éléments — default: [ { header: … }, { page: … }, { page: … }, { footer: … } ] » — les clés pour l'usuel, la liste dès que les pages se répètent. | Solde la virgule D509. Voir §3.2c. |
 | D511 | **L'acte et les deux modes** : « operation[<nom>] pour être en phase avec les fields » ; « une opération doit avoir 2 modes — la pré-exécution identifie les modifications à apporter (les factures à créer ; l'import : ajoutées/modifiées/non modifiées/supprimées) » ; le message de confirmation au gabarit nourri de la pré-exécution. | Généralise D234 et l'exécution à blanc ; `validate: { message: }` en proposition (étend D431). Voir §3.2c. |
+| D512 | **La famille `chart.*`** actée (l'écho des pickers, la note D470) : `chart.line`, `chart.bars`, `chart.pie`, `chart.combo` — et « j'ajouterais également **le nuage de points** » : `chart.scatter` ; `kpi` et `pivot` à part, la jauge restant la feuille `gauge`. | Le hook étend (`chart.radar`…) — D239. Voir §3.2c. |
+| D513 | **La carte des collections** : « le composant doit pouvoir s'adapter pour une coordonnée ou une liste de coordonnées dont des lignes sont possibles ou pas » — les marqueurs multiples, le tracé dans l'ordre de la collection. | Rien n'était consigné (vérifié) ; `lines: true \| false` en proposition (défaut false). Voir §3.2c. |
 
 ---
 
@@ -3664,6 +3666,27 @@ proposition : `validate: true` — la relecture simple, le défaut —
 s'étend en `validate: { message: <gabarit> }`, le gabarit consommant
 les résultats nommés de la pré-exécution : « {invoices} factures
 seront créées ».)*
+
+**La famille `chart.*` et le nuage de points (D512).** La famille
+pointée des graphiques est actée — l'écho des pickers, la note de D470
+tenue : **`chart.line`** (la courbe), **`chart.bars`** (les barres),
+**`chart.pie`** (les secteurs — camembert/anneau), **`chart.combo`**
+(le combiné, 2 axes Y max — D239), et l'ajout de l'auteur :
+**« j'ajouterais également le nuage de points »** — **`chart.scatter`**.
+`kpi` (le chiffre-clé) et `pivot` (le croisé dynamique D246) vivent à
+part ; la jauge reste la feuille `gauge` (D494/D498) ; le hook étend la
+famille (`chart.radar`…) sans toucher au moteur (D239).
+
+**La carte des collections (D513 — complète la fiche map).** **« Le
+composant doit pouvoir s'adapter pour une coordonnée ou une liste de
+coordonnées dont des lignes sont possibles ou pas. »** La vérification :
+rien n'était consigné — la fiche `map` servait la coordonnée seule.
+Désormais : **une coordonnée** = le marqueur (D294) ; **une liste de
+coordonnées** (`list of geolocation`, l'association aux coordonnées) =
+**les marqueurs multiples sur une même carte**, et **les lignes** —
+le tracé reliant les points dans l'ordre de la collection (l'itinéraire,
+la tournée) — **possibles ou pas**. *(L'écriture en proposition :
+`lines: true | false` — défaut `false`, les marqueurs seuls.)*
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10586,3 +10609,9 @@ avant la synthèse Q16).
   pré-exécution actés. **La famille des actes est soldée** (une fiche
   unique — l'habitat fait le visage). Restent : les graphiques
   (chart/kpi/pivot — Q53) et les surfaces.
+- **2026-08-14 (suite 9)** — **Les graphiques ouverts** : la famille
+  pointée chart.* actée avec le nuage de points (chart.scatter —
+  D512) ; kpi et pivot à part. **La carte des collections (D513)** :
+  une coordonnée ou une liste de coordonnées, les lignes possibles ou
+  pas (rien n'était consigné — la fiche map complétée ; lines: en
+  proposition). Première fiche à venir : chart.line.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -11092,3 +11092,9 @@ avant la synthèse Q16).
   `widget` écrite — la lecture proposée : une seule surface aux deux
   usages, la carte de l'enregistrement (D492) et la synthèse au
   drill-down (D202), le pool de l'accueil (D204), l'évaluation D248.
+- **2026-08-14 (suite 47, pause)** — **La fiche `widget` validée**
+  (« je valide widget ») — la lecture des deux usages en une surface
+  actée. L'auteur fait une pause. **L'état de la passe des
+  surfaces** : list, form, summary, widget validées (D530–D540) ;
+  restent wizard, dashboard, template — puis la signature des nœuds,
+  Q60, les domaines 5–8.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -600,6 +600,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D519 | **Les secteurs arbitrés** : `mode: pie \| donut \| quarter` ; les variables du gabarit `{value}`/`{percent}`/`{total}` (« {percent} % ({value} / {total}) ») ; le clic sur une part → la liste de ses éléments ; « autres » acté — **son drill affiche une barre de répartition** pour préciser la valeur à filtrer. | Le drill à deux étages. Voir §3.2c. |
 | D520 | **L'épaisseur et les angles** (complète D519) : « sur donut, l'épaisseur ; sur quarter, l'angle de départ, de fin et l'épaisseur — représenter l'assemblée nationale de la gauche vers la droite ». | `thickness:` et les angles aux bornes (`quarter[-90..90]`) en proposition ; l'hémicycle fondateur. Voir §3.2c. |
 | D521 | **Le graphique, le tableau, ou les deux** (au socle des charts) : « les charts doivent se présenter soit en graphique, soit sous forme d'un tableau — pour avoir une vue sur les différentes valeurs directement — ou les deux ». | L'écho des tableaux de valeurs D244 ; `display: graph \| table \| both` en proposition (défaut graph). Voir §3.2c. |
+| D522 | **Le nuage de points** : un point par enregistrement (le visage D386) ; « les axes se déclinent via des seuils qui ne se chevauchent pas » — la concentration/dispersion, **et la catégorisation** : « un MoSCoW en s'appuyant sur 2 critères, les gains/bénéfices de l'effort ». | `thresholds:` à l'axe riche + `zones:` (title/color, les bornes D366) en proposition ; le clic sur une zone → la liste. Voir §3.2c. |
 
 ---
 
@@ -3780,6 +3781,25 @@ valeurs directement), ou les deux. »** La présentation rejoint le
 socle commun de la famille — l'écho des tableaux de valeurs (D244).
 *(L'écriture en proposition : `display: graph | table | both` —
 défaut `graph`.)*
+
+**Le nuage de points : la dispersion et la catégorisation (D522).**
+Le grain d'abord — la lecture validée par l'usage : **le nuage montre
+les enregistrements eux-mêmes** — un point par enregistrement, `x:` et
+`y:` deux champs nus (sans agrégat), le visage au survol (D386), le
+clic ouvrant le formulaire. Puis les mots de l'auteur : **« les axes
+se déclinent également via des seuils qui ne se chevauchent pas.
+L'idée est d'utiliser un nuage de points pour représenter une
+concentration ou une dispersion d'une certaine valeur. Mais cela doit
+permettre aussi d'aider à catégoriser des éléments — par exemple, la
+réalisation d'un MoSCoW (en s'appuyant sur 2 critères), ou alors sur
+les gains/bénéfices de l'effort d'une action ou d'un ensemble
+d'actions… »** Les seuils découpent les axes en bandes, **les
+croisements font les zones** — la matrice de décision (MoSCoW,
+effort/bénéfice). *(Les écritures en proposition : `thresholds:` dans
+la forme riche de l'axe — la liste croissante, non chevauchante par
+construction ; **`zones:`** — la zone au croisement des bandes,
+`x: 0..50` aux bornes D366, `title:` et `color:` ; le clic sur une
+zone → la liste de ses éléments, l'écho D519.)*
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10751,3 +10771,8 @@ avant la synthèse Q16).
   charts doivent se présenter soit en graphique, soit sous forme d'un
   tableau, ou les deux » (l'écho D244) ; display: graph|table|both en
   proposition. Suivante : chart.scatter.
+- **2026-08-14 (suite 20)** — **Le nuage de points (D522)** : le
+  grain (un point par enregistrement, le visage D386) ; les seuils
+  d'axe non chevauchants, les zones aux croisements — la
+  catégorisation (MoSCoW, effort/bénéfice) ; thresholds:/zones: en
+  proposition. La fiche chart.scatter écrite.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -617,6 +617,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D536 | **La propriété `style:` définie** : « par défaut, le style global de l'application ; prévoyons une propriété style qui regroupe la fonte, la taille et sa mise en forme » — le thème d'instance en défaut, la surcharge à la cascade D461. | `style: { font:, size:, format: [bold…] }` en proposition (le size intérieur = la police — D458 départage). Voir §3.2c. |
 | D537 | **Le résumé précisé** : « le 1-1 affiche le title **ou l'image** si elle est définie » (le visage D386) ; petit par principe confirmé ; « plusieurs sections (pour mêler des affichages horizontaux et verticaux) — pas plusieurs pages, ni plusieurs tabs ». | L'organisateur D489–D491 dans le résumé ; D201 confirmé. Voir §3.2c. |
 | D538 | **Le graphique au résumé** : « un summary peut contenir un kpi ou un chart — à condition que son affichage reste modeste » (D243 réutilisable, la modestie D201). | `chart[<nom>]` en items en proposition (la famille des adresses D460/D483/D511). Voir §3.2c. |
+| D539 | **La troisième assise du chart** (élargit D517) : « elle s'appuie sur une entité ou un champ de type list of ou association with » — le champ-collection : le graphique des éléments liés à l'enregistrement du contexte. | `on: <champ>` en proposition. Voir §3.2c. |
 
 ---
 
@@ -3981,6 +3982,16 @@ condition (le petit par principe D201 s'étend à l'embarqué).
 *(L'écriture en proposition : **`chart[<nom>]`** en items — la
 famille des adresses, l'écho de `field[<nom>]` D460,
 `operation[<nom>]` D511 et `template[<nom>]` D483.)*
+
+**La troisième assise du chart (D539 — élargit D517).** **« Une
+précision concernant les charts : elle s'appuie sur une entité ou un
+champ de type `list of` ou `association with`. »** Le graphique se
+fonde donc sur : l'entité (porteuse par défaut — D518), la liste
+nommée (D517), **ou le champ-collection** — la composition ou
+l'association de l'enregistrement du contexte : le graphique des
+lignes de *la* commande affichée. *(L'écriture en proposition :
+`on: <champ>` — le nom du champ `list of`/`association with` de
+l'entité porteuse.)*
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11060,3 +11071,7 @@ avant la synthèse Q16).
   « un kpi ou un chart, à condition que son affichage reste
   modeste » — chart[<nom>] en items en proposition (la famille des
   adresses).
+- **2026-08-14 (suite 44)** — **La troisième assise (D539)** : « la
+  chart s'appuie sur une entité ou un champ de type list of ou
+  association with » — le champ-collection, le graphique des éléments
+  liés à l'enregistrement du contexte ; on: <champ> en proposition.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -624,6 +624,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D543 | **Le `size` des jumeaux** : le qrcode — « la taille unique pour les côtés » (`size: 120px`, le carré) ; le code-barres — « largeur × hauteur » (la grammaire D533). | Voir §3.2c. |
 | D544 | **Les deux modes du champ encodé** (précise D300/D543) : « la saisie en mode texte et l'affichage en mode graphique — la saisie peut nécessiter une size différente de l'affichage ». | `size: { input:, display: }` en proposition (la forme courte = l'affichage seul). Voir §3.2c. |
 | D545 | **La valeur sous les barres** : « l'affichage du code-barres peut nécessiter l'affichage de la valeur de la référence sous le code-barres » — l'humain sous la machine. | `labels: true` en proposition (l'écho D516, défaut false). Voir §3.2c. |
+| D546 | **Le wizard précisé** : steps/step = « un habillage de tabs[wizard] où chaque step est un tab » ; « un step peut contenir une opération sur la validation » ; les opérations de base de toute entité (create/read/update/delete, enrichies) ; la démarche guidée — créer, modifier/supprimer un ensemble d'une liste, **imprimer les menus**, mettre à jour une tournée. | `operation: <nom>` au step en proposition. Voir §3.2c. |
 
 ---
 
@@ -4052,6 +4053,24 @@ code-barres. »** La valeur lisible à l'humain, sous la valeur lisible
 à la machine — l'usage des étiquettes EAN. *(L'écriture en
 proposition : `labels: true` — l'écho D516, la valeur au format du
 champ ; défaut `false`.)*
+
+**Le wizard précisé : l'habillage, l'opération d'étape, la démarche
+(D546).** **« Le wizard avec steps/step est un habillage de
+`tabs[wizard]` où chaque step est en fait un tab. »** Le squelette est
+acté — le couple validé. **« Pour un wizard, un step peut contenir
+une opération sur la validation »** — l'opération jouée au passage de
+l'étape (l'acte D511, sa pré-exécution et son `validate:`
+s'appliquant). **« Chaque entité dispose des opérations de base
+`create`, `read`, `update` et `delete`, enrichies par d'autres
+opérations »** — le catalogue de base (l'écho D422/D433). Et la
+démarche s'élargit : **« le wizard permet de guider l'utilisateur
+dans sa démarche : la création d'un nouvel enregistrement, la
+modification/suppression d'un ensemble d'enregistrements répondant à
+une liste… »** — les usages fondateurs : **imprimer les menus** (la
+semaine → la liste des menus → le mode de diffusion), **créer un
+client**, **mettre à jour une tournée** — le wizard orchestre les
+opérations, il ne fait pas que des naissances. *(L'écriture en
+proposition : `operation: <nom>` au step.)*
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11177,3 +11196,9 @@ avant la synthèse Q16).
   transitions conditionnelles, l'état transitoire à transaction
   finale, le brouillon déclaré ; en proposition : le couple
   steps:/step:, l'if: d'étape, le draft: <état>.
+- **2026-08-14 (suite 55)** — **Le wizard précisé (D546)** :
+  l'habillage de tabs[wizard] acté (step = tab) ; l'opération à la
+  validation du step (operation: <nom> en proposition) ; les
+  opérations de base create/read/update/delete ; la démarche
+  élargie — créer, agir sur un ensemble d'une liste, imprimer les
+  menus, mettre à jour une tournée. La fiche complétée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -641,6 +641,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D560 | **Le publipostage étoffé** : « paragraph doit être étoffé pour disposer d'un mode publipostage riche et facile à intégrer » — les cinq briques en proposition : les variables au format de la langue (les chemins D71), l'`if:` conditionnel, `style:`/les titres, la source (en place ou dictionnaire D440), le multi-alinéas. | À arbitrer. Voir §3.2c. |
 | D561 | **La sixième brique** (complète D560) : « l'affichage d'une liste sous forme de bullet points ou d'indices » — la collection dans la lettre. | `{overdue[bullets]}` / `{overdue[numbers]}` en proposition (le crochet ; le `title` D465 par élément). Voir §3.2c. |
 | D562 | **Mustache + markdown au paragraph** (remplace les écritures D560–D561) : « la combinaison doit couvrir les différents cas ; des limites portant sur les composants (pas de liste, pas d'image…) » — mustache (variables, chemins, sections-itérations), markdown (titres, gras, puces, tableaux) ; `![…]` exclu, l'`if:` d'expression demeure (D90), le champ texte utilisateur reste nu (D261). | Deux standards, zéro syntaxe maison. Voir §3.2c. |
+| D563 | **Le comportement d'`url`** (les cinq points validés) : le lien en lecture — le clic ouvre dans un nouvel onglet, l'icône du lien externe en post-zone (D271/D391) ; l'icône demeure en saisie ; l'ellipse en cellule ; le lien actif au template, la valeur nue en Excel/CSV ; l'aperçu de la cible = un hook (D263). | La synthèse complétée (la ligne url séparée). Voir §3.2c. |
 
 ---
 
@@ -4259,6 +4260,20 @@ propriété de l'alinéa** (D90 — mustache est sans logique) ; la source
 (en place ou dictionnaire D440) et le multi-alinéas vont de soi. Le
 champ texte de l'utilisateur reste nu (la frontière D261 — le
 markdown n'entre pas dans la donnée).
+
+**Le comportement d'`url` (D563).** La question (« le type url
+existe-t-il ? ») a relevé le manque : le type existait (D391, la
+règle générale), son comportement non. Les cinq points validés :
+**(1) la lecture = le lien** — le clic ouvre **dans un nouvel onglet
+du navigateur**, jamais dans l'application (la pile D535 intouchée) ;
+**l'icône du lien externe en post-zone** (l'anatomie D271, la
+post-zone venant du type D391) ; **(2) la modification** — la zone de
+texte, la validation intégrée ; l'icône post-zone demeure (vérifier
+sans quitter la saisie) ; **(3) la cellule** — l'ellipse (D296), le
+clic ouvre, le double-clic édite (D446) ; **(4) le template** — le
+texte et le lien actif ; Excel/CSV — la valeur nue, ré-importable ;
+**(5) pas de prévisualisation au socle** — l'aperçu de la cible = un
+hook (la ligne D263).
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11480,6 +11495,11 @@ avant la synthèse Q16).
   standards ; les limites sur les composants (pas de liste, pas
   d'image — ![…] exclu) ; l'if: d'expression demeure ; la frontière
   D261 préservée (le champ texte utilisateur reste nu).
+- **2026-08-14 (suite 76)** — **Le comportement d'url (D563)** : la
+  question a relevé le manque (le type existait, le comportement
+  non) — les cinq points validés (le lien au nouvel onglet, l'icône
+  post-zone, l'ellipse, le lien actif au template, l'aperçu en
+  hook). La synthèse complétée.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -638,6 +638,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D557 | **L'accueil au module actif** : « une page d'accueil fait référence à un dashboard selon le module activé » — le module actif fournit son tableau de bord. | Complète D554–D556. Voir §3.2c. |
 | D558 | **La homepage aux trois pointes** (amende D557) : « la limiter à un dashboard m'embête — la homepage doit pouvoir pointer une liste, un dashboard ou une page vide ». | La lettre de D204 retrouvée ; la composition aux emplacements `_` (D555–D556). Voir §3.2c. |
 | D559 | **Le template précisé** : `margin:` en mm ; « le paragraph peut être un gabarit — le cas d'une lettre » (le publipostage, l'étoffement Q55) ; « la déclinaison par langue se porte sur chaque item » (amende la lecture de D253 — un seul gabarit, les items déclinés). | Voir §3.2c. |
+| D560 | **Le publipostage étoffé** : « paragraph doit être étoffé pour disposer d'un mode publipostage riche et facile à intégrer » — les cinq briques en proposition : les variables au format de la langue (les chemins D71), l'`if:` conditionnel, `style:`/les titres, la source (en place ou dictionnaire D440), le multi-alinéas. | À arbitrer. Voir §3.2c. |
 
 ---
 
@@ -4218,6 +4219,19 @@ l'étoffement Q55 commence ; **« la déclinaison par langue se porte
 sur chaque item »** — la lecture de D253 s'amende : **un seul
 gabarit**, ses items déclinés par langue (la mécanique D465), non un
 gabarit entier par langue.
+
+**Le publipostage étoffé (D560).** **« Paragraph doit être étoffé
+pour disposer d'un mode publipostage riche et facile à intégrer. »**
+L'étoffement proposé — cinq briques *(toutes en proposition, à
+arbitrer)* : **(1) les variables** — `{champ}` rendu au format de la
+langue du document (la conversion D369), les chemins de référence
+traversés (`{customer.address.city}` — D71) ; **(2) la condition** —
+`if:` sur le paragraphe (le bloc ne s'imprime que si — D90, l'écho
+D546) ; **(3) la mise en forme** — `style:` (D536) et les titres à
+quatre niveaux (D250) ; **(4) la source** — le texte en place
+(décliné par langue D559) ou le dictionnaire du module (D440) ;
+**(5) le multi-alinéas** — un seul `paragraph` porte plusieurs
+alinéas (la lettre s'écrit d'un bloc).
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11426,3 +11440,7 @@ avant la synthèse Q16).
   commence) ; la déclinaison par langue à chaque item (D253 amendé :
   un seul gabarit, les items déclinés). Les écarts
   template/formulaire posés dans l'échange pour revue.
+- **2026-08-14 (suite 72)** — **Le publipostage étoffé (D560)** :
+  « riche et facile à intégrer » — les cinq briques proposées
+  (variables aux chemins, if:, style:/titres, la source, le
+  multi-alinéas), l'arbitrage attendu.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -11168,3 +11168,6 @@ avant la synthèse Q16).
 - **2026-08-14 (suite 52)** — **La valeur sous les barres (D545)** :
   labels: true en proposition (l'écho D516, défaut false) — l'humain
   sous la machine.
+- **2026-08-14 (suite 53)** — **La fiche `qrcode`/`barcode` validée**
+  (« je valide qrcode/barcode ») — le manque de D542 refermé
+  (D542–D545). La passe des surfaces peut reprendre : le wizard.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -639,6 +639,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D558 | **La homepage aux trois pointes** (amende D557) : « la limiter à un dashboard m'embête — la homepage doit pouvoir pointer une liste, un dashboard ou une page vide ». | La lettre de D204 retrouvée ; la composition aux emplacements `_` (D555–D556). Voir §3.2c. |
 | D559 | **Le template précisé** : `margin:` en mm ; « le paragraph peut être un gabarit — le cas d'une lettre » (le publipostage, l'étoffement Q55) ; « la déclinaison par langue se porte sur chaque item » (amende la lecture de D253 — un seul gabarit, les items déclinés). | Voir §3.2c. |
 | D560 | **Le publipostage étoffé** : « paragraph doit être étoffé pour disposer d'un mode publipostage riche et facile à intégrer » — les cinq briques en proposition : les variables au format de la langue (les chemins D71), l'`if:` conditionnel, `style:`/les titres, la source (en place ou dictionnaire D440), le multi-alinéas. | À arbitrer. Voir §3.2c. |
+| D561 | **La sixième brique** (complète D560) : « l'affichage d'une liste sous forme de bullet points ou d'indices » — la collection dans la lettre. | `{overdue[bullets]}` / `{overdue[numbers]}` en proposition (le crochet ; le `title` D465 par élément). Voir §3.2c. |
 
 ---
 
@@ -4232,6 +4233,13 @@ quatre niveaux (D250) ; **(4) la source** — le texte en place
 (décliné par langue D559) ou le dictionnaire du module (D440) ;
 **(5) le multi-alinéas** — un seul `paragraph` porte plusieurs
 alinéas (la lettre s'écrit d'un bloc).
+
+**La sixième brique (D561 — complète D560).** **« L'affichage d'une
+liste sous forme de bullet points ou d'indices. »** La collection
+entre dans la lettre — les commandes en retard énumérées en puces ou
+numérotées. *(L'écriture en proposition : la variable-collection au
+crochet — `{overdue[bullets]}` / `{overdue[numbers]}` — chaque
+élément rendu par son `title` (D465).)*
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11444,3 +11452,7 @@ avant la synthèse Q16).
   « riche et facile à intégrer » — les cinq briques proposées
   (variables aux chemins, if:, style:/titres, la source, le
   multi-alinéas), l'arbitrage attendu.
+- **2026-08-14 (suite 73)** — **La sixième brique (D561)** : « une
+  liste sous forme de bullet points ou d'indices » — la
+  variable-collection au crochet en proposition ({overdue[bullets]},
+  le title par élément).

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -11171,3 +11171,9 @@ avant la synthèse Q16).
 - **2026-08-14 (suite 53)** — **La fiche `qrcode`/`barcode` validée**
   (« je valide qrcode/barcode ») — le manque de D542 refermé
   (D542–D545). La passe des surfaces peut reprendre : le wizard.
+- **2026-08-14 (suite 54)** — **La fiche `wizard` écrite** : le
+  matériau Q54 (D230–D233) sur le squelette tabs[wizard]
+  (D504–D505) — mono-utilisateur une session, les étapes-surfaces aux
+  transitions conditionnelles, l'état transitoire à transaction
+  finale, le brouillon déclaré ; en proposition : le couple
+  steps:/step:, l'if: d'étape, le draft: <état>.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -625,6 +625,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D544 | **Les deux modes du champ encodé** (précise D300/D543) : « la saisie en mode texte et l'affichage en mode graphique — la saisie peut nécessiter une size différente de l'affichage ». | `size: { input:, display: }` en proposition (la forme courte = l'affichage seul). Voir §3.2c. |
 | D545 | **La valeur sous les barres** : « l'affichage du code-barres peut nécessiter l'affichage de la valeur de la référence sous le code-barres » — l'humain sous la machine. | `labels: true` en proposition (l'écho D516, défaut false). Voir §3.2c. |
 | D546 | **Le wizard précisé** : steps/step = « un habillage de tabs[wizard] où chaque step est un tab » ; « un step peut contenir une opération sur la validation » ; les opérations de base de toute entité (create/read/update/delete, enrichies) ; la démarche guidée — créer, modifier/supprimer un ensemble d'une liste, **imprimer les menus**, mettre à jour une tournée. | `operation: <nom>` au step en proposition. Voir §3.2c. |
+| D547 | **La chaîne de pré-exécutions** (amende D546) : « le mode draft s'efface… les steps avec une opération sont pré-exécutés ; la transformation n'aura lieu qu'à la validation définitive du wizard » ; « avec un message de confirmation, si l'utilisateur valide, il ne pourra pas revenir en arrière » — le cliquet sur le chemin D505. | `draft:` retiré ; la transaction finale D232/D101 exécute tout. Voir §3.2c. |
 
 ---
 
@@ -4071,6 +4072,20 @@ semaine → la liste des menus → le mode de diffusion), **créer un
 client**, **mettre à jour une tournée** — le wizard orchestre les
 opérations, il ne fait pas que des naissances. *(L'écriture en
 proposition : `operation: <nom>` au step.)*
+
+**La chaîne de pré-exécutions (D547 — amende D546, retire le
+draft).** **« Le mode draft s'efface avec la possibilité de
+pré-exécuter une opération. Avec un message de confirmation, si
+l'utilisateur valide, il ne pourra pas revenir en arrière. Dans un
+wizard, les steps avec une opération sont pré-exécutés. La
+transformation n'aura lieu qu'à la validation définitive du
+wizard. »** Le wizard se referme en une mécanique pure : **les
+opérations d'étape se jouent en pré-exécution** (le chiffrage D511)
+au fil de l'avance ; **la transformation unique à la validation
+définitive** — la transaction finale (D232/D101) exécute tout d'un
+coup ; **la confirmation validée barre le retour** — le chemin
+navigable (D505) s'arrête au dernier step confirmé (le cliquet) ; la
+proposition `draft:` est retirée — la pré-exécution la remplace.
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11202,3 +11217,8 @@ avant la synthèse Q16).
   opérations de base create/read/update/delete ; la démarche
   élargie — créer, agir sur un ensemble d'une liste, imprimer les
   menus, mettre à jour une tournée. La fiche complétée.
+- **2026-08-14 (suite 56)** — **La chaîne de pré-exécutions (D547)** :
+  le draft s'efface ; les steps à opération pré-exécutés, la
+  transformation à la validation définitive ; la confirmation validée
+  barre le retour (le cliquet sur le chemin D505). La fiche
+  corrigée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -10855,3 +10855,8 @@ avant la synthèse Q16).
   style en exergue (distinct de la feuille) ; les 4 organisations —
   la position du label, l'icône au bord opposé ; layout: top|left|
   bottom|right en proposition (défaut top).
+- **2026-08-14 (suite 28)** — **La fiche `kpi` validée** (« je valide
+  kpi »). Dernière des graphiques : `pivot` — le croisé dynamique
+  (D246 : les quatre éléments, les groupements pliables) ; en
+  proposition : rows:/columns:/value:, le clic sur une cellule
+  ouvrant la liste de l'intersection.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -608,6 +608,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D527 | **L'organisation du kpi** : « mis en valeur avec un style différent de la feuille » ; « l'organisation se découpe en 4 » — la position du label (haut/gauche/bas/droite), l'icône au bord opposé. | `layout: top \| left \| bottom \| right` en proposition (défaut top ; la collision avec D490 notée). Voir §3.2c. |
 | D528 | **Le tri du croisé sur la valeur** : « visualiser les plus gros CA » — les lignes par la valeur agrégée, chaque niveau du groupement par son sous-total ; le défaut = l'ordre naturel du champ. | `sort: -value` en proposition (le signe D441). Voir §3.2c. |
 | D529 | **Le tri aux trois clés** (élargit D528) : « le tri peut s'appuyer sur les rows, les columns ou la value » — les signes et cascades D441 (`sort: { seller: -value, date: + }`). | Voir §3.2c. |
+| D530 | **Les appels du geste et les exports** : « add, update or delete pour préciser le formulaire/widget à appeler » (les défauts : le formulaire par défaut D438, les gestes D446) ; « exports: permet de préciser les différents exports ou générations de documents ». | `exports: [ csv, excel[modèle], template[gabarit] ]` en proposition. Voir §3.2c. |
 
 ---
 
@@ -3868,6 +3869,20 @@ s'appuyer sur les rows, les columns ou la value. »** La clé du tri :
 un champ des lignes, un champ des colonnes, ou la valeur — les signes
 et les cascades de D441 valent (`sort: { seller: -value, date: + }` —
 les commerciaux par leur CA décroissant, les mois chronologiques).
+
+**Les appels du geste et les exports de la liste (D530).** **« Sur la
+liste, il manque les propriétés `add`, `update` or `delete` pour
+préciser le formulaire/widget à appeler. La propriété `exports:`
+permet de préciser les différents exports ou générations de
+documents. »** Les trois gestes de D446 nomment leur surface : `add:`
+(le bouton du cadre), `update:` (le double-clic), `delete:` (la
+lecture seule + confirmation) — le formulaire ou le widget appelé,
+**le formulaire par défaut (D438) sans déclaration**. Et **`exports:`**
+précise la panoplie — les exports (D445) et **les générations de
+documents** (l'effet document, le template — D483/D511). *(L'écriture
+en proposition : `exports: [ csv, excel[stock.xlsx],
+template[order_sheet] ]` — le crochet portant le modèle ou le
+gabarit.)*
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10897,3 +10912,8 @@ avant la synthèse Q16).
   dashboard), la fiche + l'exemple + la validation à chaque étape. La
   fiche de la liste-surface écrite (le visage déclaré du composant
   unique D486).
+- **2026-08-14 (suite 33)** — **Les appels du geste et les exports
+  (D530)** : add/update/delete nomment le formulaire ou le widget
+  appelé (le défaut D438) ; exports: précise les exports et les
+  générations de documents (le crochet au modèle/gabarit en
+  proposition). La fiche complétée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -10692,3 +10692,7 @@ avant la synthèse Q16).
 - **2026-08-14 (suite 14)** — **Le défaut de l'assise (D518)** : « si
   on: est absent, l'assise porte sur l'entité elle-même » — l'entité
   porteuse de la déclaration.
+- **2026-08-14 (suite 15)** — **La fiche `chart.line` validée**
+  (« oui »). Suivante : `chart.bars` — le socle commun hérité
+  (D515–D518), les écarts propres en proposition (mode:
+  vertical|horizontal au crochet D478, stacked: pour l'empilement).

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -11500,6 +11500,9 @@ avant la synthèse Q16).
   non) — les cinq points validés (le lien au nouvel onglet, l'icône
   post-zone, l'ellipse, le lien actif au template, l'aperçu en
   hook). La synthèse complétée.
+- **2026-08-14 (suite 77)** — **La PR #25 créée** (« Q16 domaine 4 —
+  les actes, les graphiques, les surfaces : le catalogue au complet,
+  D511–D563 » — 75 commits, 2 fichiers) vers develop.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -614,6 +614,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D533 | **La grammaire de `size:`** : « 75% → 75 % de l'écran avec centrage ; 90% 50% → la longueur et la hauteur ; ou 1000px 320px en pixels » — une valeur centrée, deux valeurs largeur puis hauteur, % ou px. | Vaut partout où size s'écrit (D484). Voir §3.2c. |
 | D534 | **La confusion levée** (clarifie D532) : « j'ai introduit une confusion entre dimension et size » — la doctrine D484 départage : le formulaire s'ouvre à l'appel → `dimension:` (D454) ; la liste s'affiche → `size:` ; la grammaire D533 vaut pour les deux. | Voir §3.2c. |
 | D535 | **`size` aux surfaces, la pile des surimpressions** (amende D454/D534) : « size me convient mieux pour les 2 usages — un form ou une liste apparaissent en surimpression par rapport aux actions antécédentes cumulées » — toute surface s'ouvre au-dessus de la pile ; le couple D484 demeure au grain du champ. | Le dimension: du formulaire (D454) devient size:. Voir §3.2c. |
+| D536 | **La propriété `style:` définie** : « par défaut, le style global de l'application ; prévoyons une propriété style qui regroupe la fonte, la taille et sa mise en forme » — le thème d'instance en défaut, la surcharge à la cascade D461. | `style: { font:, size:, format: [bold…] }` en proposition (le size intérieur = la police — D458 départage). Voir §3.2c. |
 
 ---
 
@@ -3947,6 +3948,19 @@ la règle générale, non une extension particulière. Le `dimension:` du
 formulaire (D454) devient `size:` ; **le couple D484 demeure au grain
 du champ** (la vignette/la visionneuse, la mini-carte/la carte
 dépliée, le picker déployé — `dimension:`).
+
+**La propriété `style:` définie (D536).** Le retour sur `text` — et le
+mot du socle (D461) reçoit son contenu : **« par défaut, ces éléments
+sont pris dans le cadre du style global de l'application, mais nous
+pouvons avoir besoin de les surcharger. Prévoyons une propriété
+`style` qui regroupe la fonte, la taille et sa mise en forme. »** Le
+défaut : **le style global de l'instance** (le thème — le paramètre
+général, l'esprit D259) ; la surcharge à la cascade D461 (le type → le
+champ → le nœud gui, le plus proche l'emporte). *(L'écriture en
+proposition : `style: { font: Roboto, size: 14px, format: [bold,
+italic] }` — le `size` intérieur = la taille de la police, le contexte
+départageant du size d'emprise D535 (D458) ; `format:` parmi bold,
+italic, underline, strike.)*
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11009,3 +11023,7 @@ avant la synthèse Q16).
   surimpression sur la pile des actions antécédentes cumulées ; le
   dimension: du formulaire (D454) devient size: ; le couple D484
   demeure au grain du champ. La fiche form corrigée.
+- **2026-08-14 (suite 40)** — **La fiche `form` validée** (« je valide
+  form ») — et **style: défini (D536)** : le style global de
+  l'application en défaut, la surcharge {fonte, taille, mise en
+  forme} à la cascade D461. La fiche text complétée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -634,6 +634,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D553 | **Le contexte empilé de l'opération** : « le contexte ne représente pas seulement les informations de l'appel en cours mais l'ensemble des contextes qui se sont empilés jusqu'à l'usage de l'opération » — la pile des contextes, le pendant de D535 ; « l'origine de l'appel » (D455) = la pile entière. | Voir §3.2c. |
 | D554 | **Le dashboard aux deux auteurs** (unifie D204/D247) : « le dashboard est à la charge du technicien — un panel accessible depuis un menu ou une page d'accueil ; le pool est un dashboard personnalisable à l'utilisateur en piochant dans les widgets disponibles » — le même objet, deux auteurs. | La vérification : D204/D247 confirment. Voir §3.2c. |
 | D555 | **Le squelette de dashboard** (précise D554) : « le technicien décrit un ou plusieurs squelettes — avec des widgets contraints et des widgets libres » ; l'accueil composé = le squelette entièrement libre. | L'item `free` (répétable) en proposition. Voir §3.2c. |
+| D556 | **L'emplacement `_` et l'icône du choix** (amende D555) : « un widget interchangeable doit faire apparaître un icône qui permette de choisir un widget disponible selon son propre catalogue ou par sa libération » ; « "_" me parle plus que "free" — free pouvant être lui-même un nom de widget ». | L'item `_` acté ; la collision évitée par construction. Voir §3.2c. |
 
 ---
 
@@ -4179,6 +4180,17 @@ et **les emplacements libres** — l'utilisateur y pioche du pool
 (D247). *(L'écriture en proposition : l'item **`free`** —
 l'emplacement libre, répétable.)* La page d'accueil composée (D554)
 devient le cas limite : **le squelette entièrement libre.**
+
+**L'emplacement `_` et l'icône du choix (D556 — amende D555).**
+**« Dans un dashboard, un widget interchangeable doit faire
+apparaître un icône qui permette à l'utilisateur de choisir un widget
+disponible selon son propre catalogue ou par sa libération. »** —
+l'emplacement libre porte son icône : le choix s'ouvre parmi les
+widgets disponibles — le catalogue propre de l'utilisateur (le pool
+D247), ou un widget rendu disponible par la libération d'un autre
+emplacement. Et l'écriture est actée : **« "_" me parle plus que
+"free" — free pouvant être lui-même un nom de widget »** — l'item
+**`_`**, la collision évitée par construction.
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11363,3 +11375,7 @@ avant la synthèse Q16).
   les widgets contraints et les emplacements libres (l'item free en
   proposition) ; l'accueil = le squelette entièrement libre. La
   fiche complétée.
+- **2026-08-14 (suite 67)** — **L'emplacement _ (D556)** : l'icône du
+  choix sur le widget interchangeable (le catalogue propre ou la
+  libération) ; « _ » acté à la place de free (la collision évitée).
+  La fiche ajustée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -621,6 +621,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D540 | **Le chart, feuille du formulaire** : « un form peut donc avoir un composant chart comme feuille — nous le faisons entrer de fait dans summary » — `chart[<nom>]` en item du form, le résumé l'héritant (la modestie D538). | Confirme D243/D538. Voir §3.2c. |
 | D541 | **La tendance du kpi** (note pour plus tard) : « en exploitant l'historique d'une entité, nous pourrions présenter la tendance » — la valeur rejouée aux instants passés (D411/D172) ; le détail différé. | La frontière avec D245 à confirmer au moment venu. Voir §3.2c. |
 | D542 | **`qrcode` et `barcode` fichés** (répare un manque) : décidés (D252/D300 — les composants de sortie) mais absents de l'inventaire des fiches — les deux feuilles jumelles ajoutées, la fiche commune. | `barcode[ean13\|code128…]` au crochet en proposition (défaut code128) ; le scan hors D300. Voir §3.2c. |
+| D543 | **Le `size` des jumeaux** : le qrcode — « la taille unique pour les côtés » (`size: 120px`, le carré) ; le code-barres — « largeur × hauteur » (la grammaire D533). | Voir §3.2c. |
 
 ---
 
@@ -4026,6 +4027,12 @@ proposition : le format du code-barres au crochet —
 `barcode[ean13]`, `barcode[code128]` — le défaut `code128` ; la
 saisie par scan reste hors D300 — les composants sont de sortie, la
 question du scan pour plus tard si besoin.)*
+
+**Le `size` des jumeaux (D543).** **« Pour le qrcode, `size` fournit
+la taille unique pour les côtés : `size: 120px` — un qrcode de 120 px
+de côté. Pour le code-barres, `size` fournit une taille en largeur ×
+hauteur. »** Le carré par nature (une seule valeur — jamais deux), le
+rectangle à la grammaire pleine (D533).
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -11132,3 +11139,6 @@ avant la synthèse Q16).
   la question de l'auteur relève le manque — décidés (D252/D300)
   mais jamais fichés ; la fiche commune écrite, l'inventaire et la
   synthèse complétés ; le format au crochet en proposition.
+- **2026-08-14 (suite 50)** — **Le size des jumeaux (D543)** : le
+  qrcode au carré (une valeur unique — le côté), le code-barres en
+  largeur × hauteur (D533). La fiche complétée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -602,6 +602,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D521 | **Le graphique, le tableau, ou les deux** (au socle des charts) : « les charts doivent se présenter soit en graphique, soit sous forme d'un tableau — pour avoir une vue sur les différentes valeurs directement — ou les deux ». | L'écho des tableaux de valeurs D244 ; `display: graph \| table \| both` en proposition (défaut graph). Voir §3.2c. |
 | D522 | **Le nuage de points** : un point par enregistrement (le visage D386) ; « les axes se déclinent via des seuils qui ne se chevauchent pas » — la concentration/dispersion, **et la catégorisation** : « un MoSCoW en s'appuyant sur 2 critères, les gains/bénéfices de l'effort ». | `thresholds:` à l'axe riche + `zones:` (title/color, les bornes D366) en proposition ; le clic sur une zone → la liste. Voir §3.2c. |
 | D523 | **La matrice adressée** (simplifie D522) : « l'axe définit min, max et threshold ; les zones définissent les positions dans la matrice créée — plutôt que x et y, `zone: [1,1]` » — plus aucune borne répétée. | Convention `[colonne, ligne]` depuis l'origine (bas-gauche) en proposition. Voir §3.2c. |
+| D524 | **L'orientation du combiné** : « axis: left \| right, ou bottom \| up, pour une représentation en ligne contre une représentation en colonne » — la paire d'axes dit l'orientation, homogène par construction. | La virgule « up »/« top » (D504) signalée. Voir §3.2c. |
 
 ---
 
@@ -3810,6 +3811,16 @@ définissent les positions dans la matrice créée — plutôt que x et y,
 fois ; la zone s'y **adresse** par sa position — plus aucune borne
 répétée. *(La convention en proposition : `[colonne, ligne]` depuis
 l'origine des axes — `[1,1]` en bas à gauche.)*
+
+**L'orientation du combiné (D524).** **« `axis: left | right`, ou
+`bottom | up`, pour une représentation en ligne contre une
+représentation en colonne. »** Le combiné s'oriente par la paire
+d'axes : **à gauche/droite** — les valeurs debout, la représentation
+en colonne (le défaut) ; **en bas/haut** — les valeurs couchées, la
+représentation en ligne. La paire est homogène par construction (les
+deux séries du même régime). *(La virgule de vocabulaire signalée :
+« up » ici, « top » chez les tabs (D504) — l'harmonisation à
+trancher.)*
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -10795,3 +10806,6 @@ avant la synthèse Q16).
   Suivante : `chart.combo` — le combiné (D239 : courbe+barres ou 2
   courbes, 2 axes Y max) ; en proposition : y: en liste de séries
   { value:, as: line|bars, axis: left|right }.
+- **2026-08-14 (suite 23)** — **L'orientation du combiné (D524)** :
+  axis: left|right ou bottom|up — la représentation en colonne ou en
+  ligne, la paire homogène ; la virgule up/top (D504) signalée.

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -10696,3 +10696,8 @@ avant la synthèse Q16).
   (« oui »). Suivante : `chart.bars` — le socle commun hérité
   (D515–D518), les écarts propres en proposition (mode:
   vertical|horizontal au crochet D478, stacked: pour l'empilement).
+- **2026-08-14 (suite 16)** — **La fiche `chart.bars` validée** (« je
+  valide chart.bars »). Suivante : `chart.pie` — les écarts propres en
+  proposition (mode: pie|donut au crochet, la variable {percent} au
+  gabarit des labels, le regroupement des petites parts en « autres »
+  à seuil).


### PR DESCRIPTION
**Le catalogue des composants est au complet** — cette PR solde les trois dernières familles de `composants.md` (les actes, les graphiques, les surfaces) et clôt la passe « la construction des surfaces pour une entité », menée sur le fil conducteur `sales.order`. **55 décisions (D511–D565)**, 78 commits.

## Les actes (D511)
**Une fiche unique** — `operation[<nom>]`, « en phase avec les fields » : l'habitat fait le visage (le bouton au formulaire, l'icône à trois états en colonne — D444, le passage d'étape au wizard). Et **les deux modes de l'opération** : **la pré-exécution** — « identifier les modifications à apporter » (le nombre de factures à créer, les lignes ajoutées/modifiées/supprimées d'un import) — généralise le dry-run (D234) et l'exécution à blanc ; le message de confirmation au gabarit nourri de ses résultats (`validate: { message: }`).

## Les graphiques (D512–D529)
- **La famille pointée** : `chart.line`, `chart.bars` (mode vertical/horizontal, stacked), `chart.pie` (pie/donut/**quarter[-90..90]** — l'hémicycle, thickness, le drill d'« autres » à deux étages), **`chart.scatter`** (l'ajout de l'auteur — un point par enregistrement, le visage D386, les seuils d'axe et **les zones adressées `zone: [colonne, ligne]`** : le MoSCoW, l'effort/bénéfice), `chart.combo` (2 axes max, l'orientation left/right ou bottom/top) — plus `kpi` (le feu tricolore `colors:`/`icons:` par seuils, les 4 organisations `layout:`) et `pivot` (les quatre éléments D246, le tri aux trois clés rows/columns/value).
- **Le socle commun** : **l'assise** `on:` (l'entité porteuse par défaut, la liste nommée à l'adresse, **ou le champ `list of`/`association with`** — le graphique des éléments du contexte), la forme riche des axes `{ value, min, max, scale, threshold }`, `display: graph | table | both`, `labels:` au gabarit (`{value}`/`{percent}`/`{total}`), le clic ouvrant les valeurs du calcul.
- La carte enrichie en chemin (D513–D514) : la liste de coordonnées (les lieux sans relier / le parcours relié au trait droit), **le tracé de la route aux hooks** (OSRM/Valhalla en candidats — Q7).

## Les surfaces (D530–D562) — le fil `sales.order`
- **`list`** : les gestes nomment leur surface (`add:`/`update:`/`delete:`), `actions:` (l'icône au header, le bouton au pied), `exports: [ csv, excel[modèle], template[gabarit] ]`, **l'anatomie en pages** (header : titre/colonnes/filtres/icône-exports ; footer : sous-total ou gabarit) ;
- **`form`** : les cinq usages (D199), le `pages` implicite, **la pile des surimpressions** (D535 — toute surface s'ouvre au-dessus des actions antécédentes cumulées ; `size:` partout, la grammaire D533 : 1 valeur centrée / L×H / % ou px) et son pendant de données, **le contexte empilé de l'opération** (D553) ;
- **`summary`** : la config restreinte (D201), le title **ou l'image** au 1-1 (D386), les sections mêlées, les graphiques modestes ;
- **`widget`** : une surface, deux usages — la carte (D492) et la synthèse (D202), le pool (D204) ;
- **`wizard`** : steps/step, **la chaîne de pré-exécutions** (D547 — le draft s'efface, la transformation à la validation définitive, le cliquet des confirmations), `breadcrumb: none | top | bottom`, l'aide à la décision aux steps — et **la séparation tabs/wizard** (D552) : « la transactionnalité n'est pas un habillage » — deux objets, le mode wizard retiré de tabs ;
- **`dashboard`** : au module, `refresh: static | live | every[…]`, **le squelette** aux widgets contraints et emplacements **`_`** (l'icône du choix, le pool sous confidentialité), **les deux auteurs** (le technicien déclare, l'utilisateur compose), la homepage aux trois pointes (liste | dashboard | vide) ;
- **`template`** : le formulaire en lecture seule + `paper:`/`margin:`, les quatre portes (l'effet document, le viewer à la volée, les exports, l'impression serveur), l'entité contexte (D254), la déclinaison par langue **à chaque item**, **les quatre destinations** — `format: pdf | word | excel | mail`, le défaut pdf, extensible aux besoins (D564–D565) — et **le publipostage en mustache + markdown** (D562, le rendez-vous Q55 : les sections pour l'itération, `![…]` exclu, l'`if:` d'expression, le champ texte utilisateur restant nu — le mail en porte la lettre).

## En chemin
`style:` défini (D536 — fonte/taille/mise en forme, le thème global en défaut) ; **`qrcode`/`barcode` fichés** (D542–D545 — le manque relevé par l'auteur : les deux modes du champ, le size aux deux régimes, la valeur sous les barres) ; le comportement d'**`url`** (D563 — le lien au nouvel onglet, l'icône post-zone) ; la note kpi-tendance (D541, différée) ; `chart[<nom>]` feuille du formulaire (D540).

## L'état du chantier
**Les cinq familles de composants.md sont au complet** : 26 feuilles, 4 couples de conteneurs + header/footer, l'acte unique, 7 graphiques, 7 surfaces — chaque fiche validée sur exemple. Restent au domaine 4 : la signature formelle des nœuds ; puis Q60 (le catalogue des fonctions), les domaines 5–8, la passe de complétude — et le code (D314).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
