### PR TITLE
La passe de complétude — les huit domaines consignés, les connecteurs, hooks.md et types.md (D602–D609)

### DIFF
--- a/docs/conception.md
+++ b/docs/conception.md
@@ -685,6 +685,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D604 | **Le catalogue de base des connecteurs** (complète D603) : les bases de données standard (SQLServer, MySQL, Postgre…), l'AD Azure, les fichiers (CSV, JSON…) — + le géocodage (D294), l'itinéraire (D514), le smtp (D564), la reprise (D175) ; `every:` « pour rafraîchir ou tester » — le file watcher : « la détection de présence d'un fichier, le fichier mis à jour et relu ». | L'entrant naît par le fichier ; l'AD Azure = un visage de la passerelle D418. Voir §3.2c. |
 | D605 | **Le contrat par famille** (solde les connecteurs) : « la famille (ou le type) permet de définir les interactions avec Syncytium — chaque famille a ses propres méthodes et fonctions » — la ligne D579 jusqu'aux connecteurs ; le hook implémente le contrat de sa famille. | Les cinq manques du sujet refermés (D603–D605). Voir §3.2c. |
 | D606 | **Les deux sens, le stockage-connecteur, la migration inter-connecteurs** : « un connecteur décrit les sortants et les entrants » ; « les entités sont liées à un connecteur de base de données » — le stockage est un connecteur ; « une migration d'un connecteur vers un autre, en instantanée ou en différentiel ». | La translation aux 4 usages (vérifié — évoqué dès l'origine) ; le différentiel = la réplication passive (D112–D114). Voir §3.2c. |
+| D607 | **`hooks.md` créé** : le troisième artefact préparatoire (Q58/domaine 6 — la ligne du glossaire D417 et de composants.md D457) — la doctrine, les cinq familles de hooks et leurs contrats, les points d'extension, les règles transversales. | Le report des échanges consignés — aucun contenu nouveau. |
 
 ---
 
@@ -12283,6 +12284,15 @@ avant la synthèse Q16).
   un connecteur ; la migration instantanée ou différentielle (la
   réplication D112–D114) ; la translation aux quatre usages vérifiée
   (évoquée dès l'origine).
+- **2026-08-15 (suite 34)** — **hooks.md créé (D607)** : le troisième
+  artefact préparatoire (après le glossaire D417 et composants.md
+  D457) — le report des échanges sur les hooks : la doctrine (D52/
+  D408 — le catalogue = les hooks embarqués, le mot jamais écrit, la
+  première classe, la dégradation), les cinq familles aux contrats
+  (type, composant, opération, fonction, connecteur), les autres
+  points d'extension, les règles transversales (la librairie
+  inviolable, le renvoi domaine 6 relu, la signature d'abord).
+  L'entrée Connecteur du glossaire enrichie au passage (D603–D606).
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -12140,6 +12140,9 @@ avant la synthèse Q16).
   ouverte.
 - **2026-08-15 (suite 26)** — **La boîte seule (D601)** : form:
   absent + message: précisé = la boîte de dialogue seule.
+- **2026-08-15 (suite 27)** — **La PR #28 fusionnée** (« Q60 close »,
+  D570–D601, 26 commits) — develop porte le catalogue des fonctions.
+  **Le domaine 5 s'ouvre.**
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -682,6 +682,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D601 | **La boîte seule** (précise D600) : « si form: est absent et si message: est précisé, seule une boîte de dialogue de validation sera affichée » — le léger et le riche. | Voir §3.2c. |
 | D602 | **Les huit domaines de Q16 consignés** (répare un manque) : 1. l'organisation et l'arborescence · 2. la donnée, sa structure et les droits · 3. le méta-schéma · 4. les surfaces · 5. les cas d'usage · 6. la documentation · 7. l'architecture technique · 8. l'implémentation. Le recoupement : 1–4 livrés (3 = règles/comportement + Q60) ; 5=Q59, 6=Q58, 7=Q7/Q47, 8=D314 ; les renvois « domaine 6 » de D408/D452/D459 relus (couverts par Q60, le reliquat au domaine 7). | Voir §3.2c. |
 | D603 | **Les connecteurs — les cinq arbitrages** : `connectors.yml` à la racine, **global** (aucune déclinaison) ; le catalogue de base + le hook de connecteur ; les paramètres = les propriétés, **pas de contexte** (le démarrage du projet) ; **les secrets = la référence à une variable d'environnement**, chiffrable à la clé dérivée (environnement + machine) ; `every:` à la grammaire D434. | Le dépôt versionné (D336) sans secret en clair. Voir §3.2c. |
+| D604 | **Le catalogue de base des connecteurs** (complète D603) : les bases de données standard (SQLServer, MySQL, Postgre…), l'AD Azure, les fichiers (CSV, JSON…) — + le géocodage (D294), l'itinéraire (D514), le smtp (D564), la reprise (D175) ; `every:` « pour rafraîchir ou tester » — le file watcher : « la détection de présence d'un fichier, le fichier mis à jour et relu ». | L'entrant naît par le fichier ; l'AD Azure = un visage de la passerelle D418. Voir §3.2c. |
 
 ---
 
@@ -4809,6 +4810,22 @@ chiffrement à la clé dérivée (l'environnement + la machine) — le
 dépôt versionné (D336) reste propre. **(5) « `every:` reprend la même
 grammaire »** (D434/D476) — « pour des hooks qui ont besoin d'être
 régulièrement rafraîchis ».
+
+**Le catalogue de base des connecteurs (D604 — complète D603).**
+**« Le catalogue de hooks regroupe : un connecteur vers les bases de
+données standard (SQLServer, MySQL, Postgre…), un connecteur vers
+l'AD Azure, un connecteur de fichiers (CSV, JSON…) — ta liste
+complète bien la mienne. »** Le catalogue de base réunit donc : **les
+bases de données standard**, **l'AD Azure** (la passerelle
+d'authentification D418 y trouve un premier visage), **les fichiers**
+(CSV, JSON…), le géocodage (`ban`/`nominatim` — D294), l'itinéraire
+(`osrm`/`valhalla` — D514), le mail sortant (`smtp` — D564/D574), la
+reprise (D175–D179). Et l'`every:` précisé : **« utilisé pour les
+connecteurs qui ont besoin d'être régulièrement rafraîchis ou
+testés — par exemple un file watcher : la détection de présence d'un
+fichier, le fichier mis à jour et relu. »** — **l'échange entrant
+naît là** : le fichier déposé, détecté, relu — la porte d'entrée par
+le connecteur de fichiers.
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -12219,6 +12236,10 @@ avant la synthèse Q16).
   clé environnement + machine), every: D434. Le catalogue de base en
   proposition dans l'échange (la phrase de l'auteur interrompue —
   « le catalogue de hooks »).
+- **2026-08-15 (suite 31)** — **Le catalogue de base (D604)** : les
+  bases de données standard, l'AD Azure, les fichiers (CSV, JSON) —
+  la liste complémentaire acceptée ; every: pour rafraîchir ou
+  tester, le file watcher — l'entrant naît par le fichier.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -683,6 +683,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D602 | **Les huit domaines de Q16 consignés** (répare un manque) : 1. l'organisation et l'arborescence · 2. la donnée, sa structure et les droits · 3. le méta-schéma · 4. les surfaces · 5. les cas d'usage · 6. la documentation · 7. l'architecture technique · 8. l'implémentation. Le recoupement : 1–4 livrés (3 = règles/comportement + Q60) ; 5=Q59, 6=Q58, 7=Q7/Q47, 8=D314 ; les renvois « domaine 6 » de D408/D452/D459 relus (couverts par Q60, le reliquat au domaine 7). | Voir §3.2c. |
 | D603 | **Les connecteurs — les cinq arbitrages** : `connectors.yml` à la racine, **global** (aucune déclinaison) ; le catalogue de base + le hook de connecteur ; les paramètres = les propriétés, **pas de contexte** (le démarrage du projet) ; **les secrets = la référence à une variable d'environnement**, chiffrable à la clé dérivée (environnement + machine) ; `every:` à la grammaire D434. | Le dépôt versionné (D336) sans secret en clair. Voir §3.2c. |
 | D604 | **Le catalogue de base des connecteurs** (complète D603) : les bases de données standard (SQLServer, MySQL, Postgre…), l'AD Azure, les fichiers (CSV, JSON…) — + le géocodage (D294), l'itinéraire (D514), le smtp (D564), la reprise (D175) ; `every:` « pour rafraîchir ou tester » — le file watcher : « la détection de présence d'un fichier, le fichier mis à jour et relu ». | L'entrant naît par le fichier ; l'AD Azure = un visage de la passerelle D418. Voir §3.2c. |
+| D605 | **Le contrat par famille** (solde les connecteurs) : « la famille (ou le type) permet de définir les interactions avec Syncytium — chaque famille a ses propres méthodes et fonctions » — la ligne D579 jusqu'aux connecteurs ; le hook implémente le contrat de sa famille. | Les cinq manques du sujet refermés (D603–D605). Voir §3.2c. |
 
 ---
 
@@ -4826,6 +4827,20 @@ testés — par exemple un file watcher : la détection de présence d'un
 fichier, le fichier mis à jour et relu. »** — **l'échange entrant
 naît là** : le fichier déposé, détecté, relu — la porte d'entrée par
 le connecteur de fichiers.
+
+**Le contrat par famille (D605 — solde le sujet des connecteurs).**
+**« La famille (ou le type) permet de définir les interactions avec
+Syncytium. Chaque famille a ses propres méthodes et fonctions. »** —
+le contrat du hook-connecteur n'est pas universel : **il est porté
+par la famille** (la ligne D579 — le type emmène ses fonctions,
+jusqu'aux connecteurs) : la base de données a ses méthodes, le
+fichier les siennes (la veille, la lecture), le géocodage les siennes
+(l'adresse → les coordonnées, l'inverse), le mail son envoi,
+l'annuaire son authentification, la reprise sa lecture seule (D175).
+Un hook de connecteur implémente le contrat de sa famille. **Les cinq
+manques des connecteurs sont refermés** : la déclaration (D603), les
+secrets (D603), la planification (D603–D604), les entrants (D604 —
+le watcher), le contrat (D605).
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -12240,6 +12255,11 @@ avant la synthèse Q16).
   bases de données standard, l'AD Azure, les fichiers (CSV, JSON) —
   la liste complémentaire acceptée ; every: pour rafraîchir ou
   tester, le file watcher — l'entrant naît par le fichier.
+- **2026-08-15 (suite 32)** — **Le contrat par famille (D605)** :
+  chaque famille de connecteurs a ses propres méthodes et fonctions
+  (la ligne D579 jusqu'au bout) — **le sujet des connecteurs et des
+  échanges est soldé** (D603–D605, les cinq manques refermés).
+  Suivant dans la passe : la sécurité et les droits.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -12349,6 +12349,9 @@ avant la synthèse Q16).
   d'opérations du socle » (les effets = des références) ; le
   déclenchement par connecteur acté (les webhooks, l'import
   automatique) ; hooks.md mis à jour.
+- **2026-08-15 (suite 39)** — **La PR #29 créée** (« la passe de
+  complétude — les huit domaines consignés, les connecteurs, hooks.md
+  et types.md », D602–D609, 14 commits, 4 fichiers) vers develop.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -12293,6 +12293,11 @@ avant la synthèse Q16).
   points d'extension, les règles transversales (la librairie
   inviolable, le renvoi domaine 6 relu, la signature d'abord).
   L'entrée Connecteur du glossaire enrichie au passage (D603–D606).
+- **2026-08-15 (suite 35)** — **Les exemples ajoutés à hooks.md**
+  (« où sont les exemples ? ») : chaque famille reçoit le sien, puisé
+  des échanges — le type progression/fuel (le fondateur), le
+  composant gauge_3d, l'opération invoice du fil, la fonction
+  extract_name (D593), les connecteurs geocoding + le guetteur.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -686,6 +686,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D605 | **Le contrat par famille** (solde les connecteurs) : « la famille (ou le type) permet de définir les interactions avec Syncytium — chaque famille a ses propres méthodes et fonctions » — la ligne D579 jusqu'aux connecteurs ; le hook implémente le contrat de sa famille. | Les cinq manques du sujet refermés (D603–D605). Voir §3.2c. |
 | D606 | **Les deux sens, le stockage-connecteur, la migration inter-connecteurs** : « un connecteur décrit les sortants et les entrants » ; « les entités sont liées à un connecteur de base de données » — le stockage est un connecteur ; « une migration d'un connecteur vers un autre, en instantanée ou en différentiel ». | La translation aux 4 usages (vérifié — évoqué dès l'origine) ; le différentiel = la réplication passive (D112–D114). Voir §3.2c. |
 | D607 | **`hooks.md` créé** : le troisième artefact préparatoire (Q58/domaine 6 — la ligne du glossaire D417 et de composants.md D457) — la doctrine, les cinq familles de hooks et leurs contrats, les points d'extension, les règles transversales. | Le report des échanges consignés — aucun contenu nouveau. |
+| D608 | **`types.md` créé** : le quatrième artefact préparatoire (Q58/domaine 6) — le catalogue des types par croisement du registre : le socle commun (le kit, le tri, la signature D579–D584), les simples, les composés, les collections/plages, les liens, les générés et le contexte, les types-hooks. | Le report des décisions — aucun contenu nouveau. |
 
 ---
 
@@ -12307,6 +12308,11 @@ avant la synthèse Q16).
   les libres et iif (D583/D587). **Le point 8 reste ouvert à
   l'arbitrage : l'articulation entre l'opération déclarée
   (when:/effects: — D428–D432) et le hook d'opération (D570).**
+- **2026-08-15 (suite 37)** — **types.md créé (D608)** : le quatrième
+  artefact préparatoire — le catalogue des types par croisement du
+  registre (le socle commun, les simples, les composés, les
+  collections et plages, les liens, les générés et le contexte, les
+  types-hooks) ; chaque ligne cite ses décisions.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -681,6 +681,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D600 | **Le confirm au formulaire** (enrichit D595/D597) : « le rendre plus riche avec un formulaire et des champs alimentés par l'exécution — la création simplifiée validée en consultant l'enregistrement en lecture seule et/ou en modification » — les éditions rejoignent la transaction avant le scellé (D594). | `commit: { mode: confirm, form: <nom>, message: }` en proposition. Voir §3.2c. |
 | D601 | **La boîte seule** (précise D600) : « si form: est absent et si message: est précisé, seule une boîte de dialogue de validation sera affichée » — le léger et le riche. | Voir §3.2c. |
 | D602 | **Les huit domaines de Q16 consignés** (répare un manque) : 1. l'organisation et l'arborescence · 2. la donnée, sa structure et les droits · 3. le méta-schéma · 4. les surfaces · 5. les cas d'usage · 6. la documentation · 7. l'architecture technique · 8. l'implémentation. Le recoupement : 1–4 livrés (3 = règles/comportement + Q60) ; 5=Q59, 6=Q58, 7=Q7/Q47, 8=D314 ; les renvois « domaine 6 » de D408/D452/D459 relus (couverts par Q60, le reliquat au domaine 7). | Voir §3.2c. |
+| D603 | **Les connecteurs — les cinq arbitrages** : `connectors.yml` à la racine, **global** (aucune déclinaison) ; le catalogue de base + le hook de connecteur ; les paramètres = les propriétés, **pas de contexte** (le démarrage du projet) ; **les secrets = la référence à une variable d'environnement**, chiffrable à la clé dérivée (environnement + machine) ; `every:` à la grammaire D434. | Le dépôt versionné (D336) sans secret en clair. Voir §3.2c. |
 
 ---
 
@@ -4789,6 +4790,25 @@ hooks — signature, code, sandbox) furent écrits sous un découpage de
 travail antérieur : **ils se relisent** — le contrat est couvert par
 Q60 (D570–D601), le reliquat (la sandbox, le langage du code) relève
 du domaine 7.
+
+**Les connecteurs : les cinq arbitrages (D603 — la passe de
+complétude, premier sujet).** **(1) « `connectors.yml` est bien à la
+racine de la version. Il ne trouve pas de déclinaison dans les
+modules, ni les entités. Un connecteur est global. »** **(2) « Les
+connecteurs sont disponibles dans un catalogue de base offert par
+Syncytium et sont extensibles via un hook de connecteur. »**
+**(3) « Les paramètres d'un connecteur sont juste les propriétés du
+connecteur. Le connecteur n'a pas de contexte, car il se définit au
+démarrage du projet »** — hors de la pile (D553), l'exception
+assumée. **(4) « Les secrets sont définis dans la configuration…
+Les secrets peuvent faire référence à une variable d'environnement,
+et la variable peut être cryptée via une clé construite en fonction
+de l'environnement et de la machine d'exécution. »** — la
+configuration porte la référence, jamais la valeur en clair ; le
+chiffrement à la clé dérivée (l'environnement + la machine) — le
+dépôt versionné (D336) reste propre. **(5) « `every:` reprend la même
+grammaire »** (D434/D476) — « pour des hooks qui ont besoin d'être
+régulièrement rafraîchis ».
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -12193,6 +12213,12 @@ avant la synthèse Q16).
   connecteurs et les échanges ». Les cinq manques du sujet : la
   déclaration, les secrets, le contrat du hook-connecteur, les
   entrants, la planification.
+- **2026-08-15 (suite 30)** — **Les connecteurs arbitrés (D603)** :
+  global à la racine, le catalogue + le hook, les paramètres sans
+  contexte, les secrets par variable d'environnement chiffrable (la
+  clé environnement + machine), every: D434. Le catalogue de base en
+  proposition dans l'échange (la phrase de l'auteur interrompue —
+  « le catalogue de hooks »).
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -687,6 +687,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D606 | **Les deux sens, le stockage-connecteur, la migration inter-connecteurs** : « un connecteur décrit les sortants et les entrants » ; « les entités sont liées à un connecteur de base de données » — le stockage est un connecteur ; « une migration d'un connecteur vers un autre, en instantanée ou en différentiel ». | La translation aux 4 usages (vérifié — évoqué dès l'origine) ; le différentiel = la réplication passive (D112–D114). Voir §3.2c. |
 | D607 | **`hooks.md` créé** : le troisième artefact préparatoire (Q58/domaine 6 — la ligne du glossaire D417 et de composants.md D457) — la doctrine, les cinq familles de hooks et leurs contrats, les points d'extension, les règles transversales. | Le report des échanges consignés — aucun contenu nouveau. |
 | D608 | **`types.md` créé** : le quatrième artefact préparatoire (Q58/domaine 6) — le catalogue des types par croisement du registre : le socle commun (le kit, le tri, la signature D579–D584), les simples, les composés, les collections/plages, les liens, les générés et le contexte, les types-hooks. | Le report des décisions — aucun contenu nouveau. |
+| D609 | **Le pont de l'opération** (referme le point 8) : le hook = l'opération, la déclaration = l'usage et le déclenchement hors-IHM (`when:`, `every:`, **l'événement de connecteur** — les webhooks, l'import automatique) ; **« une opération peut être une liste d'opérations disponibles dans le socle »** — les effets D432 = des références aux hooks, la composition déclarative sans code, la même transaction (D594). | `when: <nom du connecteur>` en proposition. Voir §3.2c. |
 
 ---
 
@@ -4738,6 +4739,35 @@ d'exploration (D572) est l'unique porte, et elle porte les règles.
 unifiées dans les types (D579–D587), le contexte courant et les
 paramètres (D588–D591), les graphes acycliques (D592), les signatures
 des hooks (D593–D599) — le catalogue des fonctions est complet.
+
+**Le pont de l'opération : le hook et la déclaration (D609 — referme
+le point 8 de la relecture des hooks).** La clé de l'auteur :
+**« l'opération elle-même est un hook de code. Par contre,
+l'utilisation de l'opération dans l'application répond à plusieurs
+usages dépendant du mode de déclenchement. La déclaration des
+opérations permet de décrire une opération et son mode de
+déclenchement quand il n'est pas lié à l'IHM — par exemple, sur une
+mise à jour, sur la réception d'un fichier. »** Les deux plans : **le
+hook = l'opération** (l'objet D595, la transaction D594) ; **la
+déclaration (`operations:` — D432) = l'usage** — le nom, les
+paramètres, le `commit:` (D596), la garde (D430), et **le
+déclenchement hors-IHM** : `when: <expression>` (D428), `every:
+continuous` (D435 — « sur une mise à jour »), le calendaire (D434),
+**l'événement de connecteur** — acté : « utile pour traiter des
+webhooks ou pour déclencher automatiquement un process d'import »
+*(l'écriture en proposition : `when: <nom du connecteur>` — le
+contexte départage, D458)* ; l'IHM lie sans déclaration de
+déclenchement (le bouton D511, la colonne D444, les actions D531, le
+step D546, le menu D439). **Et la composition déclarative est
+actée** : **« une opération peut être une liste d'opérations
+disponibles dans le socle »** — les effets de D432 se relisent comme
+**des références aux hooks du socle** (`notify` → l'opération notify,
+`document` → generate, `set` → update, `function` → un hook de
+fonction) : « ne se construit pas dans la configuration » (D570)
+signifie *pas de code* — l'orchestration de références, elle, est
+déclarative. La séquence s'exécute **dans la même transaction tenue
+ouverte** (D594) ; le chiffrage, le confirm et l'issue valent pour
+les deux formes.
 
 **Le confirm au formulaire (D600 — enrichit D595/D597).** **« Sur les
 opérations, nous avons `confirm` qui affiche une boîte de dialogue
@@ -12313,6 +12343,12 @@ avant la synthèse Q16).
   registre (le socle commun, les simples, les composés, les
   collections et plages, les liens, les générés et le contexte, les
   types-hooks) ; chaque ligne cite ses décisions.
+- **2026-08-15 (suite 38)** — **Le pont de l'opération (D609)** : le
+  point 8 refermé — le hook = l'opération, la déclaration = l'usage
+  et le déclenchement hors-IHM ; « une opération peut être une liste
+  d'opérations du socle » (les effets = des références) ; le
+  déclenchement par connecteur acté (les webhooks, l'import
+  automatique) ; hooks.md mis à jour.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -12298,6 +12298,15 @@ avant la synthèse Q16).
   des échanges — le type progression/fuel (le fondateur), le
   composant gauge_3d, l'opération invoice du fil, la fonction
   extract_name (D593), les connecteurs geocoding + le guetteur.
+- **2026-08-15 (suite 36)** — **hooks.md complété des sept manques**
+  (le croisement systématique du registre — la relecture de l'auteur
+  les pressentait) : la collection-type aux agrégats (D580), le type
+  label (D585–D586), le contexte et les settings lus par les hooks
+  (D553/D588–D591), le composant au nom du type (D458), le wizard et
+  la transaction (D547/D594), la migration inter-connecteurs (D606),
+  les libres et iif (D583/D587). **Le point 8 reste ouvert à
+  l'arbitrage : l'articulation entre l'opération déclarée
+  (when:/effects: — D428–D432) et le hook d'opération (D570).**
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -684,6 +684,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D603 | **Les connecteurs — les cinq arbitrages** : `connectors.yml` à la racine, **global** (aucune déclinaison) ; le catalogue de base + le hook de connecteur ; les paramètres = les propriétés, **pas de contexte** (le démarrage du projet) ; **les secrets = la référence à une variable d'environnement**, chiffrable à la clé dérivée (environnement + machine) ; `every:` à la grammaire D434. | Le dépôt versionné (D336) sans secret en clair. Voir §3.2c. |
 | D604 | **Le catalogue de base des connecteurs** (complète D603) : les bases de données standard (SQLServer, MySQL, Postgre…), l'AD Azure, les fichiers (CSV, JSON…) — + le géocodage (D294), l'itinéraire (D514), le smtp (D564), la reprise (D175) ; `every:` « pour rafraîchir ou tester » — le file watcher : « la détection de présence d'un fichier, le fichier mis à jour et relu ». | L'entrant naît par le fichier ; l'AD Azure = un visage de la passerelle D418. Voir §3.2c. |
 | D605 | **Le contrat par famille** (solde les connecteurs) : « la famille (ou le type) permet de définir les interactions avec Syncytium — chaque famille a ses propres méthodes et fonctions » — la ligne D579 jusqu'aux connecteurs ; le hook implémente le contrat de sa famille. | Les cinq manques du sujet refermés (D603–D605). Voir §3.2c. |
+| D606 | **Les deux sens, le stockage-connecteur, la migration inter-connecteurs** : « un connecteur décrit les sortants et les entrants » ; « les entités sont liées à un connecteur de base de données » — le stockage est un connecteur ; « une migration d'un connecteur vers un autre, en instantanée ou en différentiel ». | La translation aux 4 usages (vérifié — évoqué dès l'origine) ; le différentiel = la réplication passive (D112–D114). Voir §3.2c. |
 
 ---
 
@@ -4841,6 +4842,22 @@ Un hook de connecteur implémente le contrat de sa famille. **Les cinq
 manques des connecteurs sont refermés** : la déclaration (D603), les
 secrets (D603), la planification (D603–D604), les entrants (D604 —
 le watcher), le contrat (D605).
+
+**Les deux sens, le stockage-connecteur, la migration
+inter-connecteurs (D606 — élargit D603–D605).** **« Un connecteur
+décrit les sortants et les entrants. »** Et la vérification demandée
+(« il me semble que je l'avais déjà évoqué ») : oui — la translation
+déclarative fut posée dès l'origine comme **le primitif transverse
+aux quatre usages** (les migrations, les API, **les connecteurs**, la
+réplication) ; **« Syncytium peut convertir ou transférer des données
+d'un connecteur à l'autre »** en est l'exercice. Les précisions
+nouvelles : **« les entités sont liées à un connecteur de base de
+données »** — **le stockage même est un connecteur** (les bases du
+catalogue D604 ne servent pas que l'échange : elles portent
+l'instance) ; et **« nous pouvons prévoir une migration d'un
+connecteur vers un autre, en instantanée ou en différentiel »** — le
+changement de moteur (SQLServer → PostgreSQL…) par la translation,
+le différentiel rejoignant la réplication passive (D112–D114).
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -12260,6 +12277,12 @@ avant la synthèse Q16).
   (la ligne D579 jusqu'au bout) — **le sujet des connecteurs et des
   échanges est soldé** (D603–D605, les cinq manques refermés).
   Suivant dans la passe : la sécurité et les droits.
+- **2026-08-15 (suite 33)** — **Le stockage-connecteur et la
+  migration inter-connecteurs (D606)** : les deux sens décrits ; les
+  entités liées à un connecteur de base de données — le stockage est
+  un connecteur ; la migration instantanée ou différentielle (la
+  réplication D112–D114) ; la translation aux quatre usages vérifiée
+  (évoquée dès l'origine).
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -12185,6 +12185,14 @@ avant la synthèse Q16).
   l'architecture (Q7/Q47), 8 = l'implémentation (D314) ; les renvois
   « domaine 6 » de D408/D452/D459 relus vers Q60 et le domaine 7. Le
   manque réparé — le domaine 5 (les cas d'usage) prêt à s'ouvrir.
+- **2026-08-15 (suite 29)** — **La passe de complétude ouverte** : la
+  revue des manques sur les quatre sujets transversaux (les
+  connecteurs/échanges, la sécurité/droits, l'administration/
+  exploitation, la migration/versions) posée dans l'échange ; l'auteur
+  tranche — « nous allons compléter les manques, commençons par les
+  connecteurs et les échanges ». Les cinq manques du sujet : la
+  déclaration, les secrets, le contrat du hook-connecteur, les
+  entrants, la planification.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -680,6 +680,7 @@ de description au modèle en neuf rubriques (D457), même vocation.
 | D599 | **L'inviolabilité de la librairie** (clôt les signatures — **et Q60**) : « la librairie mise en place assure l'inviolabilité des règles et des droits » — le hook citoyen du moteur : droits (D196), confidentialité, validation (D307), concurrence (D111) jamais contournables. | Le catalogue des fonctions est complet (D570–D599). Voir §3.2c. |
 | D600 | **Le confirm au formulaire** (enrichit D595/D597) : « le rendre plus riche avec un formulaire et des champs alimentés par l'exécution — la création simplifiée validée en consultant l'enregistrement en lecture seule et/ou en modification » — les éditions rejoignent la transaction avant le scellé (D594). | `commit: { mode: confirm, form: <nom>, message: }` en proposition. Voir §3.2c. |
 | D601 | **La boîte seule** (précise D600) : « si form: est absent et si message: est précisé, seule une boîte de dialogue de validation sera affichée » — le léger et le riche. | Voir §3.2c. |
+| D602 | **Les huit domaines de Q16 consignés** (répare un manque) : 1. l'organisation et l'arborescence · 2. la donnée, sa structure et les droits · 3. le méta-schéma · 4. les surfaces · 5. les cas d'usage · 6. la documentation · 7. l'architecture technique · 8. l'implémentation. Le recoupement : 1–4 livrés (3 = règles/comportement + Q60) ; 5=Q59, 6=Q58, 7=Q7/Q47, 8=D314 ; les renvois « domaine 6 » de D408/D452/D459 relus (couverts par Q60, le reliquat au domaine 7). | Voir §3.2c. |
 
 ---
 
@@ -4753,6 +4754,41 @@ validation sera affichée. »** — les deux visages du confirm : la
 boîte au message (le léger), le formulaire sur la transaction (le
 riche) ; le message accompagne le formulaire quand les deux sont
 déclarés.
+
+**Les huit domaines de Q16, enfin consignés (D602 — répare un
+manque).** Le découpage vivait dans les échanges sans être posé au
+document ; l'auteur le repose :
+
+1. **l'organisation et l'arborescence d'une application** — « revue
+   et amendée au fur et à mesure de nos explorations » ;
+2. **la donnée, sa structure et les droits** ;
+3. **le méta-schéma** ;
+4. **les surfaces** ;
+5. **les cas d'usage** ;
+6. **la rédaction de la documentation synthétique et détaillée** ;
+7. **le choix de l'architecture technique** ;
+8. **l'implémentation**.
+
+**Le recoupement des échanges** (la demande de l'auteur) : les
+domaines 1 (D335–D346, amendé au fil — les dossiers module/entité,
+gui) et 2 (D347–D419 — les types, l'historisation, les groupes, la
+confidentialité au socle) sont livrés ; le domaine 3 fut vécu sous
+l'intitulé « les règles et le comportement » (D420–D436) — sa part du
+méta-schéma — que Q60 (D570–D601, le langage et les hooks) complète ;
+le domaine 4 est soldé (D437–D569, le catalogue entier). **Les
+domaines 5–8 correspondent aux chantiers déjà nommés** : 5 = les cas
+d'usage (Q59 — les mises en situation), 6 = la documentation (Q58 —
+le glossaire, composants.md et la synthèse en préparation), 7 =
+l'architecture technique (Q7, Q47 — la spec du langage, le langage
+des hooks D570, la sandbox), 8 = l'implémentation (D314 — le code
+après la conception). **Deux réconciliations consignées** : (a)
+l'intitulé du domaine 3 — « le méta-schéma » englobe les règles, le
+comportement et le langage (D420–D436 + D570–D601) ; (b) **les
+renvois « domaine 6 » des décisions D408/D452/D459** (le contrat des
+hooks — signature, code, sandbox) furent écrits sous un découpage de
+travail antérieur : **ils se relisent** — le contrat est couvert par
+Q60 (D570–D601), le reliquat (la sandbox, le langage du code) relève
+du domaine 7.
 
 **`selection` = le nombre, `by` = la présentation (D474 — solde
 D472).** **« La propriété `selection` définit le nombre d'éléments à
@@ -12143,6 +12179,12 @@ avant la synthèse Q16).
 - **2026-08-15 (suite 27)** — **La PR #28 fusionnée** (« Q60 close »,
   D570–D601, 26 commits) — develop porte le catalogue des fonctions.
   **Le domaine 5 s'ouvre.**
+- **2026-08-15 (suite 28)** — **Les huit domaines consignés (D602)** :
+  le découpage reposé par l'auteur et croisé avec les échanges — 1–4
+  livrés, 5 = les cas d'usage (Q59), 6 = la documentation (Q58), 7 =
+  l'architecture (Q7/Q47), 8 = l'implémentation (D314) ; les renvois
+  « domaine 6 » de D408/D452/D459 relus vers Q60 et le domaine 7. Le
+  manque réparé — le domaine 5 (les cas d'usage) prêt à s'ouvrir.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/glossaire.md
+++ b/docs/glossaire.md
@@ -52,7 +52,21 @@ le même numéro, jamais de trou. Il peut être réinitialisé sous condition. M
 donnée : `public` (partout), `protected` (l'interface et les tâches),
 `private` (les tâches seulement) — resserrable par groupes. *(D25)*
 
-**Connecteur** — Une passerelle entre Syncytium et un système tiers. Le connecteur peut être utilisé dans les 2 sens : en lecture/écriture selon les spécificités techniques implémentées. *(D79)*
+**Connecteur** (`connectors.yml`) — Une passerelle entre Syncytium et
+un système tiers : une base de données, un annuaire, des fichiers, un
+géocodeur, un serveur de mail… Le connecteur décrit ses entrants et
+ses sortants — la lecture et l'écriture selon les spécificités de sa
+famille. Il est **global** : déclaré à la racine de la version, sans
+déclinaison par module ni entité. Sa famille définit ses méthodes ;
+ses propriétés le paramètrent (pas de contexte — il naît au démarrage
+du projet) ; ses secrets référencent des variables d'environnement
+(chiffrables) ; `every:` le rafraîchit ou le teste (le guetteur de
+fichiers). Le stockage des entités est lui-même un connecteur de base
+de données — et Syncytium sait convertir ou transférer d'un
+connecteur à l'autre. *(D79, D603–D606)*
+
+Exemple : `geocoding: { hook: ban, parameters: { url: … },
+secrets: [api_key] }`.
 
 **Crochet** (`type[paramètre]`) — La convention d'écriture qui glisse
 un paramètre dans un nom : `text[3..10]`, `time[hh:mm]`,

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -141,6 +141,23 @@ le module, l'application. `commit: auto | confirm` à la déclaration
 (D596). L'opération voit **la pile des contextes** (D553) et peut
 appeler une fonction — jamais l'inverse (D571).
 
+**Le pont hook/déclaration (D609)** : le hook **est** l'opération ;
+la déclaration (`operations:` — D432) en décrit **l'usage** — le nom,
+les paramètres, le `commit:`, la garde `if` (D430), et **le mode de
+déclenchement quand il n'est pas lié à l'IHM** : `when:
+<expression>` (D428), `every: continuous` (D435 — sur une mise à
+jour), le calendaire (D434), **l'événement de connecteur** (les
+webhooks, l'import automatique à la réception d'un fichier —
+`when: <nom du connecteur>` en proposition). L'IHM lie sans
+déclaration (le bouton, la colonne, les actions, le step, le menu).
+**Et la composition déclarative** : « une opération peut être une
+liste d'opérations disponibles dans le socle » — les effets de D432
+sont **des références aux hooks** (`notify` → notify, `document` →
+generate, `set` → update, `function` → une fonction) ; « ne se
+construit pas dans la configuration » signifie *pas de code* —
+l'orchestration de références est déclarative, et la séquence
+s'exécute **dans la même transaction tenue ouverte** (D594).
+
 **L'exemple** — le fil `sales.order` :
 
 ```yaml

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -56,6 +56,22 @@ graphe de conversion).
 - **la représentation obligatoire** (D459) : « aucun type sans
   visage » — le composant d'écran et/ou le rendu de document.
 
+**L'exemple** — le fondateur des échanges (« définir un type
+progression… puis un champ avancement de type progression ») :
+
+```yaml
+# le type déclaré au setting (l'instance, le module ou l'entité)
+settings:
+  types:
+    progression:
+      type: integer[0..100]        # le socle du type (le chaînage possible)
+      component: fuel              # son visage (D459)
+
+# l'usage — comme un type du socle (D408 : le mot hook n'apparaît pas)
+fields:
+  avancement: progression
+```
+
 ### 2. Le hook de composant (D64–D68, D452, D566)
 
 Ajoute **un composant graphique** au catalogue — une feuille, un
@@ -69,6 +85,20 @@ commune (l'adresse `<type>[<nom>]`, le `visible:` vivant,
 l'évaluation paresseuse, les enfants déclarés, la pile de contexte —
 D566–D567) — et **« l'écriture repasse toujours par les champs et
 leurs règles »** : le composant ne contourne jamais le modèle.
+
+**L'exemple** — consigné à l'ère du modèle unifié (« le champ écrit
+`gauge_3d` comme il écrirait un composant du socle ») :
+
+```yaml
+# le hook enregistre « gauge_3d » au catalogue des composants —
+# l'objet gère le rendu Web, PDF, Word, Excel, Email (D566.7)
+
+# l'usage — la première classe (D65/D68) :
+fields:
+  progress_ring:
+    type: percentage
+    component: gauge_3d            # comme un built-in ; s'il échoue, le repli (D68)
+```
 
 ### 3. Le hook d'opération (D570, D594–D601)
 
@@ -93,6 +123,25 @@ le module, l'application. `commit: auto | confirm` à la déclaration
 (D596). L'opération voit **la pile des contextes** (D553) et peut
 appeler une fonction — jamais l'inverse (D571).
 
+**L'exemple** — le fil `sales.order` :
+
+```yaml
+# sales/entities/order.yml — la déclaration référence le hook par son nom
+operations:
+  invoice:
+    scope: selection               # les cinq portées (D570)
+    commit:
+      mode: confirm                # auto | confirm (D596)
+      form: default                # la relecture au formulaire (D600)
+      message: { fr: "{nb_creations} factures créées" }   # les valeurs nommées (D598)
+```
+
+Le hook `invoice` (le code) : `execute` crée les factures **dans la
+transaction tenue ouverte** ; `confirm` laisse le moteur présenter le
+formulaire et le message ; `commit` scelle et retourne l'issue
+(`download` du PDF, par exemple) ; `rollback` défait si l'utilisateur
+annule.
+
 ### 4. Le hook de fonction (D571, D592–D593)
 
 Ajoute **une fonction** — le calcul pur : une valeur (ou une liste)
@@ -104,6 +153,21 @@ statique D581 s'y appuie), le contexte en lecture seule — **aucune
 écriture, aucune opération déclenchée** (la pureté D571). Le moteur
 appelle au fil du **graphe d'exécution acyclique** (D592 — le cycle =
 une erreur d'ingestion), au paramètre modifié.
+
+**L'exemple** — la regex aux groupes nommés (D593) :
+
+```yaml
+# la déclaration du hook (la signature — le code au langage de Syncytium)
+functions:
+  extract_name:
+    parameters: { raw: text }
+    result: { prenom: text, nom: text }   # les valeurs nommées (D593)
+
+# l'usage — un seul calcul, deux champs (le graphe D592)
+fields:
+  prenom: { formula: extract_name(raw).prenom }
+  nom:    { formula: extract_name(raw).nom }
+```
 
 ### 5. Le hook de connecteur (D603–D606)
 
@@ -122,6 +186,22 @@ propriétés paramètrent (pas de contexte — le démarrage du projet),
 **les secrets par variable d'environnement chiffrable** (D603), les
 deux sens décrits (D606) — et **le stockage des entités est lui-même
 un connecteur** (D606).
+
+**L'exemple** — la déclaration à la racine (D603–D604) :
+
+```yaml
+# connectors.yml — à la racine de la version, global (D603)
+connectors:
+  geocoding:
+    hook: ban                      # le catalogue de base (D294/D604)
+    parameters: { url: https://api-adresse.data.gouv.fr }
+    secrets: [api_key]             # la référence — la valeur en variable
+                                   # d'environnement, chiffrable (D603)
+  incoming_orders:
+    hook: file                     # le connecteur de fichiers (D604)
+    parameters: { path: /exchange/in, format: csv }
+    every: 5min                    # le guetteur — détecté, relu (D604)
+```
 
 ### Les autres points d'extension consignés
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,150 @@
+# Les hooks de Syncytium
+
+Ce document rassemble **les échanges consignés sur les hooks** — le
+mécanisme unique d'extension de Syncytium. Il prépare la documentation
+à rédiger (Q58, le domaine 6 — D602) et suit le vocabulaire du
+[glossaire](glossaire.md) ; les décisions citées renvoient à la
+[conception](conception.md) ; les composants graphiques au
+[catalogue](composants.md).
+
+## La doctrine
+
+- **Un seul mécanisme, dedans comme dehors** (D52) : les hooks, les
+  connecteurs et les composants relèvent d'un mécanisme uniforme —
+  ce que Syncytium embarque et ce que le technicien ajoute passent
+  par la même porte ;
+- **« Tous les types proposés sont finalement des hooks qui
+  appartiennent à Syncytium »** (D408) — **le catalogue = les hooks
+  embarqués** : le socle n'est pas un cas particulier, il est le
+  premier client du mécanisme ;
+- **Le mot « hook » n'apparaît jamais dans la configuration**
+  (D408) : un hook ajoute **un nom** au catalogue concerné (un type,
+  un composant, une opération, une fonction, un connecteur) — et ce
+  nom s'emploie comme un nom du socle ; le doublon de nom = une
+  erreur d'ingestion (D344/D396) ;
+- **La première classe** (D65/D68) : un élément ajouté a les mêmes
+  droits que le socle — mappable en défaut de type, surchargeable au
+  champ ; **le registre est namespacé** (D52), les éléments
+  partageables (AGPL — l'écosystème D68) ;
+- **La dégradation** (D68) : si un hook échoue, **le repli sur le
+  built-in par défaut** ;
+- **Un hook de code définit une signature et un code propre au
+  langage exploité par Syncytium** (D570) — le langage et la sandbox
+  relèvent du domaine 7 (l'architecture technique — D602).
+
+## Les familles
+
+### 1. Le hook de type (D408, D459, D579–D584)
+
+Ajoute **un type** au catalogue — exploitable comme les types
+standard (le chaînage possible, les types custom ne portant pas le
+graphe de conversion).
+
+**La signature du type porte :**
+- **la conversion intrinsèque** (D579) — la fonction au nom du type
+  (`text(x)`, `montype(x)`) ; la promotion implicite sans perte
+  seulement (D581) ;
+- **la table des opérateurs** (D581) — les combinaisons d'opérandes
+  admises et le type du résultat ;
+- **les comparateurs** (D582) — l'ordre des règles de tri, l'égalité
+  de l'équivalence ; le `select` (D584) ;
+- **les fonctions dédiées** (D579) — `distance`/`euclide` pour la
+  géolocalisation : « un type emmène avec lui des fonctions
+  dédiées » ;
+- **les règles de tri et le nul** (D368 et suivantes), la recherche,
+  le masque — le kit des facettes ;
+- **la représentation obligatoire** (D459) : « aucun type sans
+  visage » — le composant d'écran et/ou le rendu de document.
+
+### 2. Le hook de composant (D64–D68, D452, D566)
+
+Ajoute **un composant graphique** au catalogue — une feuille, un
+conteneur, une surface (D455 : « une facette = un hook »).
+
+**Le contrat (D566.7)** : « un objet qui se chargera de gérer le
+composant **et son rendu dans les différents formats — Web, PDF,
+Word, Excel, Email…** » (les destinations D564). Le composant
+personnalisé est **un nœud comme les autres** (D452) — la signature
+commune (l'adresse `<type>[<nom>]`, le `visible:` vivant,
+l'évaluation paresseuse, les enfants déclarés, la pile de contexte —
+D566–D567) — et **« l'écriture repasse toujours par les champs et
+leurs règles »** : le composant ne contourne jamais le modèle.
+
+### 3. Le hook d'opération (D570, D594–D601)
+
+Ajoute **une opération** — « une opération ne se construit pas dans
+la configuration : elle se construit toujours à l'aide d'un hook de
+code » (D570). Les 17 opérations de socle (D574) sont les hooks
+embarqués : `create`, `read`, `update`, `delete`, `duplicate`,
+`promote`, `demote`, `generate`, `download`, `print`, `send`,
+`export`, `import`, `report`, `restore`, `notify`, `refresh`.
+
+**Le contrat — l'objet aux quatre fonctions (D595) :**
+
+| la fonction | le rôle |
+|---|---|
+| `execute` | remplit **la transaction tenue ouverte** (D594) — le preview est l'exécution suspendue avant le commit |
+| `confirm` | la relecture — le message-label (D597) aux valeurs nommées (`nb_creations`, `nb_updates`, `nb_deletes`… — D598), ou un formulaire nourri par la transaction (D600–D601) |
+| `commit` | scelle — et **retourne l'issue** (l'écran, le téléchargement, l'impression, le message, rien — D570/D597) : le moteur lit et déclenche |
+| `rollback` | défait proprement |
+
+Les cinq portées (D570) : l'enregistrement, la liste, la sélection,
+le module, l'application. `commit: auto | confirm` à la déclaration
+(D596). L'opération voit **la pile des contextes** (D553) et peut
+appeler une fonction — jamais l'inverse (D571).
+
+### 4. Le hook de fonction (D571, D592–D593)
+
+Ajoute **une fonction** — le calcul pur : une valeur (ou une liste)
+aux types du modèle, ou **des valeurs nommées** (D593 — la regex à
+groupes nommés nourrit plusieurs champs d'un seul appel).
+
+**Le contrat** : les paramètres typés, le résultat déclaré (le typage
+statique D581 s'y appuie), le contexte en lecture seule — **aucune
+écriture, aucune opération déclenchée** (la pureté D571). Le moteur
+appelle au fil du **graphe d'exécution acyclique** (D592 — le cycle =
+une erreur d'ingestion), au paramètre modifié.
+
+### 5. Le hook de connecteur (D603–D606)
+
+Ajoute **un connecteur** — la passerelle globale (`connectors.yml` à
+la racine, aucune déclinaison — D603). Le catalogue de base (D604) :
+les bases de données standard (SQLServer, MySQL, PostgreSQL…), l'AD
+Azure, les fichiers (CSV, JSON — le guetteur à `every:`), le
+géocodage (`ban`/`nominatim` — D294), l'itinéraire
+(`osrm`/`valhalla` — D514), le mail (`smtp` — D564), la reprise
+(D175–D179).
+
+**Le contrat par famille (D605)** : « chaque famille a ses propres
+méthodes et fonctions » — la base de données les siennes, le fichier
+sa veille et sa lecture, le géocodage son adresse et son inverse. Les
+propriétés paramètrent (pas de contexte — le démarrage du projet),
+**les secrets par variable d'environnement chiffrable** (D603), les
+deux sens décrits (D606) — et **le stockage des entités est lui-même
+un connecteur** (D606).
+
+### Les autres points d'extension consignés
+
+- **les écrans et les formats CSV/Excel** (D418 — le glossaire les
+  élargit) ; **les graphiques au-delà de 2 axes** (D239) ; **le
+  recadrage d'image** (D263 — le patron) ; **le tracé de la route**
+  (D514) ; **la comparaison du kpi** (D245) ; **la proximité en
+  filtre** (D294) ; **les formats du template** (D565 — « étendu à
+  d'autres formats en fonction des besoins ») ; **les fonctions
+  libres** (D587 — « le catalogue s'enrichira, si besoin »).
+
+## Les règles transversales
+
+1. **La librairie d'exploration** (D572/D599) : le hook lit le modèle
+   « de façon transparente » (les noms logiques, jamais le stockage)
+   et écrit dans la transaction — **« la librairie mise en place
+   assure l'inviolabilité des règles et des droits »** : les droits
+   (D196), la confidentialité (D25/D364), la validation (D307), la
+   concurrence par champ (D111) ne se contournent pas — **le hook est
+   un citoyen du moteur, jamais un super-utilisateur** ;
+2. **Le renvoi historique « domaine 6 »** (D408/D452/D459) se relit
+   (D602) : le contrat des hooks est couvert par Q60 (D570–D601) ; le
+   reliquat — la sandbox, le langage du code — relève du domaine 7 ;
+3. **La signature d'abord** : chaque famille déclare ce que le typage
+   statique (D581) et l'ingestion (D330/D344) vérifient — l'erreur ne
+   passe jamais l'ingestion.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -51,10 +51,28 @@ graphe de conversion).
 - **les fonctions dédiées** (D579) — `distance`/`euclide` pour la
   géolocalisation : « un type emmène avec lui des fonctions
   dédiées » ;
+- **le composant par défaut au nom du type** (D458) — le type-hook
+  nomme son composant comme le socle nomme les siens ; le contexte
+  départage les espaces de noms ;
 - **les règles de tri et le nul** (D368 et suivantes), la recherche,
   le masque — le kit des facettes ;
 - **la représentation obligatoire** (D459) : « aucun type sans
   visage » — le composant d'écran et/ou le rendu de document.
+
+**La collection est un type — et porte les agrégats** (D580) : les
+fonctions de la collection (`list of`, `association with`) sont ses
+méthodes — `commandes.sum(montant if etat = "facturée")` (l'élément
+en contexte implicite dans la parenthèse), `count()`, `avg`,
+`min`/`max` (universels — tous les types sont triables, D575),
+`first`, `last`, `any`, `exists` ; la forme contextuelle sans préfixe
+quand la collection est le contexte (l'assise d'un chart — D517).
+
+**Le type `label`** (D585–D586) — le type-hook du socle qui montre la
+voie : l'accès au catalogue des labels (D440), les gabarits nommés
+paramétrables (`label(mon_nom, { prenom: …, nom: … })` — l'ordre des
+mots par langue), et l'enregistrement en paramètre
+(`label(mon_nom, customer)` — « le nom des champs devient les
+paramètres »).
 
 **L'exemple** — le fondateur des échanges (« définir un type
 progression… puis un champ avancement de type progression ») :
@@ -142,6 +160,24 @@ formulaire et le message ; `commit` scelle et retourne l'issue
 (`download` du PDF, par exemple) ; `rollback` défait si l'utilisateur
 annule.
 
+**Le wizard, la même transaction** (D546–D547/D594) : les steps qui
+portent une `operation:` s'exécutent **dans la transaction du
+wizard, tenue ouverte au fil des étapes** — « la transformation
+n'aura lieu qu'à la validation définitive du wizard » ; la
+confirmation validée barre le retour (le cliquet — D505/D547) ;
+l'abandon annule tout.
+
+**Ce que le hook lit** : **la pile des contextes** (D553 —
+l'opération au fond de la pile voit le périmètre de la liste,
+l'enregistrement du formulaire, le transitoire du wizard),
+**`context.`** (D589 — `user` traversable, `location`, `now`,
+`instance`/`application`/`module`, `entity`/`field`,
+`file`/`page`/`pages` au document) et **`context.settings.<nom>`**
+(D588/D591 — `{ mode: static | dynamic, type:, value: }`, la
+cascade application → module → entité, le dynamique ajusté au module
+d'administration — D573). La fonction lit le contexte **en lecture
+seule** (D571).
+
 ### 4. Le hook de fonction (D571, D592–D593)
 
 Ajoute **une fonction** — le calcul pur : une valeur (ou une liste)
@@ -153,6 +189,12 @@ statique D581 s'y appuie), le contexte en lecture seule — **aucune
 écriture, aucune opération déclenchée** (la pureté D571). Le moteur
 appelle au fil du **graphe d'exécution acyclique** (D592 — le cycle =
 une erreur d'ingestion), au paramètre modifié.
+
+**Les fonctions libres** (D583/D587) complètent le monde des
+fonctions : les variadiques scalaires (`min`, `max`, `sum`, `avg` —
+`max(0, stock.sum(quantity))`) et `iif(condition, alors, sinon)` —
+« le catalogue s'enrichira, si besoin » : la porte des hooks de
+fonction libre.
 
 **L'exemple** — la regex aux groupes nommés (D593) :
 
@@ -185,7 +227,13 @@ sa veille et sa lecture, le géocodage son adresse et son inverse. Les
 propriétés paramètrent (pas de contexte — le démarrage du projet),
 **les secrets par variable d'environnement chiffrable** (D603), les
 deux sens décrits (D606) — et **le stockage des entités est lui-même
-un connecteur** (D606).
+un connecteur** (D606) : les bases du catalogue portent l'instance,
+pas seulement l'échange. **La migration inter-connecteurs** (D606) :
+« Syncytium peut convertir ou transférer des données d'un connecteur
+à l'autre » — le changement de moteur (SQLServer → PostgreSQL…) par
+la translation déclarative (le primitif aux quatre usages), **en
+instantané ou en différentiel** — le différentiel rejoignant la
+réplication passive du PCA-PRA (D112–D114).
 
 **L'exemple** — la déclaration à la racine (D603–D604) :
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -1,0 +1,112 @@
+# Le catalogue des types de Syncytium
+
+Ce document référence **tous les types consignés** — le quatrième
+artefact préparatoire de la documentation (Q58, le domaine 6 — D602),
+après le [glossaire](glossaire.md), le [catalogue des
+composants](composants.md) et les [hooks](hooks.md). Chaque type
+renvoie à ses décisions dans la [conception](conception.md) ; les
+composants par défaut et compatibles vivent dans la synthèse de
+composants.md.
+
+## Le socle commun
+
+- **le nom du type est la clé** (D408) — un seul espace de noms :
+  le catalogue, les types personnalisés (D359), les entités (D396 —
+  le raccourci de référence), les types-hooks ; le doublon = une
+  erreur d'ingestion ;
+- **le kit des facettes** (commun à tous — D391) : `label` (les
+  libellés par langue — D465), `description`/`comment` (l'aide,
+  l'infobulle — D209/D258), `validation` (les règles, expression D90
+  booléenne + message), `values` (l'énuméré — la clé stockée, les
+  libellés, la description, l'icône ; l'attention aux migrations à
+  valeur intercalée), `searchable` (strict / normalized /
+  similarity[0.8] / range / mutualizable[nom] — selon le type),
+  `mask`, `report:` (`no` par défaut — D406), la confidentialité
+  (D25/D364), `component`/`style`/`size` (la cascade D461 — le plus
+  proche l'emporte) ;
+- **le tri et le nul** (D368 et suivantes) — chaque type porte sa
+  règle ; **le nul des composés se trie en premier** (D391) ;
+- **la signature du type** (D579–D584) : **la conversion
+  intrinsèque** (la fonction au nom du type — `text(x)`, `date(x)` ;
+  la promotion implicite sans perte seulement — D581), **la table des
+  opérateurs** (les combinaisons admises, le type du résultat), **les
+  comparateurs** (l'ordre des règles de tri), **le `select`**
+  (`valeur.select(cas: …, "...": défaut)`), **les fonctions dédiées** ;
+- **le typage statique à l'ingestion** (D581) — l'inférence de la
+  feuille à la racine, jamais une erreur de type à l'exécution ;
+- **le type personnalisé** (D359) : déclaré au `settings` (l'instance,
+  le module ou l'entité) — un nom, un type de base, des facettes
+  figées ; **le chaînage possible** ; les types custom ne portent pas
+  le graphe de conversion ;
+- **le composant par défaut porte le nom du type** (D458).
+
+## Les types simples
+
+| le type | la nature et les facettes propres | le tri, le nul | D |
+|---|---|---|---|
+| `boolean` | les trois états (faux → vrai → nul) ; `required` retire le nul (la recherche strict filtre alors vrai & faux par la case « null ») | null < faux < vrai | D373–D375 |
+| `text` | la taille `auto` ou `text[30]` (les bornes au nom — D366) ; le masque (`_`, `9`, les littéraux, les classes — il pilote les lignes) ; mono/multi-ligne **déduit de la taille** face au seuil d'instance ; la recherche complète (strict/normalized/similarity/mutualizable) | le nul = la chaîne vide | D259–D265, D366–D370 |
+| `integer` | les bornes au nom (`integer[100]`, `integer[0..100]`, `integer[0..]`) ou `min`/`max` ; **les octets jamais déclarés** — dimensionnés selon les bornes ou les valeurs (« le mode auto ») ; le masque (`000000`, `00 00 00`) ; la recherche `range` | le nul = 0 | D371–D372 |
+| `decimal` | les décimales (le setting ou 2) ; **le stockage exact ou réel** (`storage:` — l'entier aux décimales converties) | le nul = 0 | D376–D378 |
+| `duration` | le masque — **la virgule : l'heure ou la minute en centièmes, l'heure en dix-millièmes** ; les unités `s`/`min`/`h`/`d`/`w`/`m`/`y` (D476) | le nul = 0 | D380, D476 |
+| `date` | **la nature au crochet** : `date[yyyy-mm]`, `date[yyyy-mm-dd]`, `date[yyyy-ww]`… — la plus fine par défaut ; le masque de la langue ; les bornes en littéraux ISO ; `date - date → duration` (D581) | le nul en tête | D381–D383 |
+| `time` | la précision au crochet (`time[hh:mm]`) | le nul en tête | D381 |
+| `datetime` | la nature au crochet : `datetime[raw]` (défaut) \| `datetime[timestamp]` ; la précision en second paramètre | le nul en tête | D381 |
+| `file` | les `extensions` (`[pdf, docx]` ou la forme à libellés `{ pdf: { fr: facture } }` — elle guide le dépôt) ; le `quota` contrôlé à la volée | — | D160–D165, D292, D384 |
+| `image` | dérive de `file` ; **la boîte maximale au crochet** (`image[512x512]`) — la vignette automatique ; le `placeholder` (l'icône de fond — D390) ; le champ image d'une entité = **le visage** sélectionnable (D386) | — | D385–D390 |
+| `thumbnail` | la vignette seule — l'image réduite d'un fichier | — | D389, D393 |
+| `uuid` | les identifiants externes (les systèmes tiers, les clés de reprise) ; la validation intégrée, le stockage compact ; **la saisie et la lecture en texte formaté** (D499) — l'UUID interne reste hors déclaration (D142) | — | D419, D499 |
+| `password` | la saisie masquée aux garanties structurelles — jamais relue | — | D463 |
+| `color` | **le stockage : un entier** (le RGB(A) assemblé) ; **l'affichage en hexadécimal** (`#RRGGBB`, l'alpha en option) ; **la base des couleurs nommées** → RGB (`red`, `orange`, `green` — celles de `colors:` D467) | le tri sur l'entier, le nul en premier | D496 |
+
+## Les composés
+
+Ils héritent du kit de la base + la validation intégrée + leurs
+facettes propres (D391). Le nul de chaque composé se trie en premier.
+
+| le type | la nature et les facettes propres | D |
+|---|---|---|
+| `amount` | les devises paramétrables (`currencies` — défaut : tout l'ISO) ; `amount + amount` à devise compatible, `amount * decimal` (D581) | D391 |
+| `percentage` | les bornes — défaut 0..100 ; hors cadre, **la représentation varie** (la jauge vaut pour le cadre) | D273–D274, D391 |
+| `measure` | les unités : **statiques** (`units: [kg, g, t]`), **la table de référence** (`units: stock.unit`), ou **libres** (défaut) | D391 |
+| `phone` | le national (défaut) ou l'international | D391 |
+| `geolocation` | les coordonnées + **le texte associé** (l'adresse, le lieu — la saisie ou le géocodage D294) ; **le tri = la distance à vol d'oiseau à une focale** (`focus:` au champ ou au setting — défaut : la localisation courante) ; la conversion en texte = le texte associé, sinon les coordonnées standardisées ; `distance`/`euclide` (D579) | D291, D294, D391–D392 |
+| `period` | hérite du format date/heure — le crochet (`period[yyyy-mm]`…) ; **début ≤ fin intégré** ; la recherche `range` en usage roi | D391 |
+| `email`, `url`, `vat_number`, `siren`, `siret`, `iban`, `bic` | la règle générale — la validation intégrée suffit ; `url` : **le lien en lecture** (le nouvel onglet, l'icône post-zone, l'ellipse en cellule — D563) | D391, D563 |
+| `communication` | le fil (un canal = un champ, non listable — D166) ; `attachments: false` (défaut) ou le type d'attaché à plat ; la visibilité par la confidentialité ; la recherche sur le contenu des messages | D295, D393 |
+| `label` | l'accès au catalogue des labels (D440) ; **le gabarit nommé paramétrable** — `label(mon_nom, { prenom: … })` ou l'enregistrement en paramètre (`label(mon_nom, customer)`) ; l'ordre des mots par langue | D585–D586 |
+
+## Les collections et les plages
+
+| le type | la nature | D |
+|---|---|---|
+| `list of <type simple>` | « la phrase se lit » ; **les facettes du champ s'appliquent à chaque élément** ; les énumérés (`values:`) → la multi-sélection ; **la collection est un type — elle porte les agrégats en méthodes** (`sum`, `count()`, `avg`, `min`/`max`, `first`, `last`, `any`, `exists` — l'élément en contexte implicite) | D296, D362, D580 |
+| `range of <type>` | « la déclinaison de `list of` avec 2 contraintes en nombre et en ordre » — deux valeurs, la première ≤ la seconde (la contrainte intégrée) ; **min et/ou max indéfinissables** (la plage ouverte) ; les libellés sur trois éléments (min, value, max) ; **la jauge = un cas particulier d'un range** | D497–D498 |
+
+## Les liens
+
+| le type | la nature | D |
+|---|---|---|
+| la référence — `<module>.<entité>` | « si le type est le nom d'une entité, c'est une référence » (le `to` inutile) ; **l'origine se lit par `me.`** dans le filtre ; `check: selection` (défaut) \| `immutable` ; l'accès retour automatique (la liste nommée) | D394–D398, D216 |
+| la composition — `list of <entité>` | le lien de possession : le parent déclare, l'enfant ne déclare rien ; **l'agrégat = le grain d'écriture** (indivisible) | D399–D400, D420 |
+| l'association — `association with <entité>` | plusieurs, libres, inter-modules — sans cascade ; reprend les propriétés de la référence (filter/me./check, l'affichage au visage) | D400–D401 |
+| le lien n-aire — `list of [a, b]` / `association with [a, b]` | **chaque élément = une combinaison des entités nommées**, des propriétés par entité nommée | D402 |
+| l'association dérivée — `association with <entité> if …` | la vue navigable, jamais stockée, en lecture — la vérité reste la référence | D405 |
+
+## Les générés et le contexte
+
+| le type | la nature | D |
+|---|---|---|
+| `counter` | le compteur — attaché au champ ou **mutualisé** (`counter[mon_compteur]`) ; la réinitialisation sur la déclaration (`reset: never` défaut) ; lecture seule partout, « *(attribué à la validation)* » en création | D154–D155, D297, D409–D410 |
+| le champ calculé | `formula:` — l'expression D90 ; lecture seule, **recalculé dès qu'une dépendance change** ; son composant = celui de son type de résultat ; les valeurs nommées d'une fonction se lient au point (D593) | D255, D298 |
+| le statut — `states:` | désigne le porteur (la hiérarchie D353 ou le champ énuméré) ; le graphe promote/demote ; un seul statut par entité | D421–D427 |
+| l'entité `context` | le moteur, lecture seule — `user` (traversable), `location`, `now`, `instance`/`application`/`module`, `entity`/`field`, `file`/`page`/`pages` (au document), `settings.<nom>` (les paramètres statiques/dynamiques en cascade) ; l'entité homonyme prend le pas (le warning à l'ingestion) | D254, D588–D591 |
+
+## Les types-hooks
+
+Tout type ajouté suit le contrat de la famille (voir
+[hooks.md](hooks.md)) : la signature complète (la conversion, les
+opérateurs, les comparateurs, les fonctions dédiées, le tri) et **la
+représentation obligatoire** — « aucun type sans visage » (D459).
+L'exemple fondateur : le type `progression` (`integer[0..100]` +
+`component: fuel`), le champ `avancement: progression`.


### PR DESCRIPTION
**La passe de complétude s'ouvre — et deux documents naissent.** La revue des quatre sujets transversaux (les connecteurs/échanges, la sécurité/droits, l'administration/exploitation, la migration/versions) a livré ses manques ; le premier sujet est traité, le découpage des huit domaines est enfin consigné, et la documentation préparatoire gagne deux artefacts. **8 décisions (D602–D609)**, 14 commits, 4 fichiers.

## Les huit domaines de Q16, consignés (D602)
Le découpage vivait dans les échanges sans être posé au document — réparé : 1. l'organisation et l'arborescence · 2. la donnée, sa structure et les droits · 3. le méta-schéma · 4. les surfaces · 5. **les cas d'usage** (Q59) · 6. **la documentation** (Q58) · 7. **l'architecture technique** (Q7/Q47) · 8. **l'implémentation** (D314). Le recoupement : les domaines 1–4 livrés ; les renvois « domaine 6 » historiques (D408/D452/D459) relus — couverts par Q60, le reliquat (la sandbox, le langage) au domaine 7.

## Les connecteurs et les échanges (D603–D606)
- **Les cinq arbitrages** (D603) : `connectors.yml` à la racine — **le connecteur est global** ; le catalogue de base + le hook de connecteur ; les paramètres = les propriétés, **pas de contexte** (le démarrage du projet) ; **les secrets = la référence à une variable d'environnement**, chiffrable à la clé dérivée (l'environnement + la machine) — le dépôt versionné reste propre ; `every:` pour rafraîchir ou tester ;
- **le catalogue de base** (D604) : les bases de données standard (SQLServer, MySQL, PostgreSQL…), l'AD Azure, les fichiers (CSV, JSON — **le guetteur** : « la détection de présence d'un fichier, le fichier mis à jour et relu » — l'entrant naît là), le géocodage, l'itinéraire, le smtp, la reprise ;
- **le contrat par famille** (D605) : « chaque famille a ses propres méthodes et fonctions » — la ligne D579 jusqu'aux connecteurs ;
- **le stockage-connecteur** (D606) : « les entités sont liées à un connecteur de base de données » — et **la migration inter-connecteurs, en instantané ou en différentiel** (la réplication passive D112–D114).

## Le pont de l'opération (D609 — le point 8 refermé)
La relecture des hooks a révélé une articulation jamais tranchée entre l'opération *déclarée* (D428–D432) et le *hook* d'opération (D570). La clé de l'auteur : **le hook est l'opération ; la déclaration en décrit l'usage et le mode de déclenchement hors-IHM** — `when:`, `every: continuous` (« sur une mise à jour »), le calendaire, **l'événement de connecteur** (les webhooks, l'import automatique). Et **« une opération peut être une liste d'opérations disponibles dans le socle »** — les effets de D432 relus comme des références aux hooks : l'orchestration déclarative sans code, dans la même transaction tenue ouverte (D594).

## Les deux documents nouveaux
- **`docs/hooks.md`** (D607) : la doctrine (le catalogue = les hooks embarqués, le mot jamais écrit, la première classe, la dégradation), **les cinq familles et leurs contrats** (le type, le composant, l'opération, la fonction, le connecteur), les exemples puisés des échanges (le type `progression`, le composant `gauge_3d`, l'opération `invoice`, la fonction `extract_name`, le guetteur), les règles transversales (la librairie inviolable) — complété après relecture de l'auteur (la collection-type, le label, le contexte lu par les hooks, le wizard-transaction, la migration inter-connecteurs) ;
- **`docs/types.md`** (D608) : le catalogue des types — le socle commun (le kit des facettes, le tri et le nul, la signature du type, le typage statique), les simples, les composés, les collections et plages, les liens, les générés et le contexte, les types-hooks ;
- **le glossaire** : l'entrée Connecteur enrichie (D603–D606).

## L'état du chantier
La passe de complétude continue — restent sur les connecteurs : les contrats détaillés par famille, la grammaire de liaison au stockage, le mapping des transferts, la défaillance ; puis la sécurité/les droits (le RGPD en tête), l'administration/l'exploitation (la télémétrie Q12–Q13), la migration/les versions. Ensuite : les domaines 5–8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
