### PR TITLE
La sécurité et les droits — le sujet 2 de la passe de complétude soldé (D690–D708)

### DIFF
--- a/docs/conception.md
+++ b/docs/conception.md
@@ -87,7 +87,7 @@ points ne sont pas validés). Les huit domaines en sont la carte —
 | 3 | **Le méta-schéma** — les règles, le comportement et le langage | Livré | D420–D436, Q60 (D570–D601) |
 | 4 | **Les surfaces** | Livré | D437–D569 |
 | 5 | **Les cas d'usage** — les mises en situation sur exemples concrets | À couvrir | Q59 |
-| 6 | **La rédaction de la documentation synthétique et détaillée** | En préparation | Q58 — glossaire, composants, hooks, types, connectors, mapping |
+| 6 | **La rédaction de la documentation synthétique et détaillée** | En préparation | Q58 — glossaire, composants, hooks, types, connectors, mapping, rights |
 | 7 | **Le choix de l'architecture technique** | À couvrir | Q7, Q47 |
 | 8 | **L'implémentation** | Après tout le reste | D314 |
 
@@ -100,10 +100,11 @@ documentation) :
    mapping/, les migrations déclarées, le module de suivi historisé,
    `migrate` la 18e opération, le versionnement plein, le
    différentiel par comparaison) ;
-2. **la sécurité et les droits** — à ouvrir ; les flags accumulés :
-   la passerelle d'authentification (D418), l'authentification du
-   `directory` (D633), le mécanisme de la garde du webhook (D642) ;
-   le RGPD (dont la tension avec l'historisation D168), l'audit ;
+2. **la sécurité et les droits** — **ouvert** (rights.md — D690) :
+   l'acquis consolidé ; les cinq points au chantier —
+   l'authentification (D418/D633/D642), le droit de déclencher, le
+   RGPD (la tension avec l'historisation D168), l'audit des
+   lectures, le chiffrement ;
 3. **l'administration et l'exploitation** — à ouvrir ; le module
    d'administration jamais décrit, la télémétrie (Q12–Q13) ;
 4. **la migration et les versions** — largement soldée : le mapping
@@ -809,6 +810,7 @@ documentation) :
 | D687 | **L'enregistrement, un type structuré du moteur** : propre à Syncytium et **multi-storage** — le storage se charge de sa conversion en stockage (les fonctions de valeur D683) ; le storage convertit, jamais ne définit. | Voir §3.2c. |
 | D688 | **Le lot au contrat d'enregistrement** (complète D680) : create/update/delete portent une liste d'enregistrements — le traitement par lot, spécifique à l'implémentation du storage (le bulk natif) ; le contrat n'impose que la forme. | Voir §3.2c. |
 | D689 | **Le curseur en lecture** (complète D688) : read() retourne un curseur, pas une liste évaluée — le lazy loading, le traitement en masse au suivi de progression ; le curseur convertit chaque ligne en un enregistrement reflétant la description des champs de l'entité (D683/D687), au fil du parcours. | L'écriture en lots, la lecture au curseur. Voir §3.2c. |
+| D690 | **`rights.md` créé** : le huitième artefact préparatoire (Q58) — la sécurité et les droits consolidés (la doctrine P8, la confidentialité D25/D364, les droits d'action D196/D422–D423, l'audience anti-IDOR D70–D77, les groupes/modules, les connecteurs, la provenance) + les cinq points du chantier du sujet 2 ; aucun contenu nouveau. | À la demande de l'auteur — la méthode des connecteurs. |
 
 ---
 
@@ -14062,6 +14064,12 @@ avant la synthèse Q16).
   « Le mapping, la jonction versions↔storage et le contrat storage
   refondé (D643–D689) », 42 commits sur develop. **Le sujet 2 de la
   passe s'ouvre : la sécurité et les droits.**
+- **2026-08-16 (suite 52)** — **rights.md créé (D690)** : le
+  huitième artefact — l'acquis consolidé (P8, la confidentialité,
+  les allow, l'audience, les groupes, les connecteurs, la trace) et
+  les cinq points ouverts du chantier (l'authentification, le droit
+  de déclencher, le RGPD, l'audit, le chiffrement). Le §1.2 mis au
+  niveau.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -14058,6 +14058,10 @@ avant la synthèse Q16).
   read() retourne un curseur — le lazy loading, la masse au suivi de
   progression ; la ligne convertie en enregistrement au fil du
   parcours. L'écriture en lots, la lecture au curseur.
+- **2026-08-16 (suite 51)** — **La PR #31 fusionnée (vérifiée)** :
+  « Le mapping, la jonction versions↔storage et le contrat storage
+  refondé (D643–D689) », 42 commits sur develop. **Le sujet 2 de la
+  passe s'ouvre : la sécurité et les droits.**
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -828,6 +828,7 @@ documentation) :
 | D705 | **Le chiffrement en transit** : ce que Syncytium sert = HTTPS sans dérogation ; ce qu'il appelle = chiffré par défaut, l'exception déclarée au connecteur (`unencrypted:` en proposition — signalée, visible au describe). | « Je valide ce point. » Voir §3.2c. |
 | D706 | **Le chiffrement au repos — l'affaire du type** : le storage hors responsabilité de Syncytium (l'infrastructure) ; pas de facette — **un type chiffrant** (comme password) : le type qui a le pouvoir chiffre par ses fonctions de valeur (D683) et déclare ses capacités restantes. | Voir §3.2c. |
 | D707 | **Les clés obligatoirement chiffrées** (durcit D603 — solde le chiffrement) : les variables d'environnement (.env) jamais versionnées ; les commandes Syncytium chiffrent avant l'enregistrement (l'automatisation flaguée) ; le déchiffrement à l'usage ; le périmètre — les clés d'API, les mots de passe de connecteurs, les clés des types chiffrants (D706). | Voir §3.2c. |
+| D708 | **Les commandes encrypt/decrypt** (incarne D707) : `encrypt <variable> <clé>` chiffre et enregistre au .env (ou autre fichier) ; `decrypt <variable>` retourne la valeur (le débogage, la vérification d'un service). « Ces 2 commandes complètent la partie sécurité. » | Voir §3.2c. |
 
 ---
 
@@ -6422,6 +6423,22 @@ secret :
 4. **le périmètre** : les clés d'API, les mots de passe de
    connecteurs… — et les clés des types chiffrants (D706) : un seul
    patron pour tout ce qui est secret.
+
+**Les deux commandes — encrypt et decrypt (D708 — incarne D707,
+complète la partie sécurité).** Les commandes propres à Syncytium
+prennent forme :
+
+- **`encrypt <nom de la variable d'environnement> <clé à
+  chiffrer>`** — chiffre la clé et l'enregistre dans le `.env` (ou
+  un autre fichier si nécessaire) ;
+- **`decrypt <nom de la variable d'environnement>`** — retourne la
+  valeur qui a été chiffrée — « pour des besoins de débogage et de
+  vérification du bon fonctionnement d'un service ».
+
+*(La lecture notée : les commandes s'exécutent sur la machine — la
+clé dérivée environnement + machine (D603) fait que le `.env` copié
+ailleurs reste muet ; le decrypt n'est utile qu'à qui a déjà la
+machine.)* **« Ces 2 commandes complètent la partie sécurité. »**
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -14417,6 +14434,10 @@ avant la synthèse Q16).
   chiffrement est soldé. Le chantier sécurité n'a plus de point
   ouvert consigné — la clôture du sujet 2 attend la relecture de
   l'auteur.
+- **2026-08-16 (suite 62)** — **encrypt/decrypt (D708)** : les deux
+  commandes consignées — le chiffrement vers le .env, le
+  déchiffrement de vérification ; la partie sécurité complétée.
+  rights.md mis au niveau.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -811,6 +811,7 @@ documentation) :
 | D688 | **Le lot au contrat d'enregistrement** (complète D680) : create/update/delete portent une liste d'enregistrements — le traitement par lot, spécifique à l'implémentation du storage (le bulk natif) ; le contrat n'impose que la forme. | Voir §3.2c. |
 | D689 | **Le curseur en lecture** (complète D688) : read() retourne un curseur, pas une liste évaluée — le lazy loading, le traitement en masse au suivi de progression ; le curseur convertit chaque ligne en un enregistrement reflétant la description des champs de l'entité (D683/D687), au fil du parcours. | L'écriture en lots, la lecture au curseur. Voir §3.2c. |
 | D690 | **`rights.md` créé** : le huitième artefact préparatoire (Q58) — la sécurité et les droits consolidés (la doctrine P8, la confidentialité D25/D364, les droits d'action D196/D422–D423, l'audience anti-IDOR D70–D77, les groupes/modules, les connecteurs, la provenance) + les cinq points du chantier du sujet 2 ; aucun contenu nouveau. | À la demande de l'auteur — la méthode des connecteurs. |
+| D691 | **Les droits d'action couvrent les opérations** (referme le point 2 du chantier) : le socle (les 18) et les déclarées — le droit d'exécuter se déclare comme les autres droits d'action (D196) ; la réconciliation avec D422 : l'opération passe outre les allow d'état, le droit de la déclencher se contrôle. | Voir §3.2c. |
 
 ---
 
@@ -6132,6 +6133,20 @@ type structuré D687) reflétant la description des champs de l'entité
 mémoire : le lazy loading des listes (D227), le traitement en masse
 au suivi de progression (la migration D667 et son module de suivi
 D666–D668, le composant progression).
+
+**Les droits d'action couvrent les opérations (D691 — referme le
+point 2 du chantier sécurité).** **« Les droits d'action couvrent
+les opérations du socle et les opérations déclarées. »** — le modèle
+de D196 (les droits d'action par entité au modèle de
+confidentialité) s'étend explicitement **aux dix-huit opérations du
+socle et aux opérations déclarées** : le droit d'exécuter se déclare
+et se contrôle comme les autres droits d'action. **La
+réconciliation avec D422** (« les opérations passent outre ») : deux
+choses distinctes — l'opération autorisée **passe outre les `allow`
+d'état de l'entité** (le promote écrit un enregistrement que l'état
+fige — l'acte porte sa légitimité), mais **le droit de déclencher
+l'opération** relève des droits d'action (D196/D691) : on contrôle
+qui appuie, pas ce que l'acte a le droit d'écrire.
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -14070,6 +14085,11 @@ avant la synthèse Q16).
   les cinq points ouverts du chantier (l'authentification, le droit
   de déclencher, le RGPD, l'audit, le chiffrement). Le §1.2 mis au
   niveau.
+- **2026-08-16 (suite 53)** — **Les droits d'action étendus aux
+  opérations (D691)** : « les droits d'action couvrent les
+  opérations du socle et les opérations déclarées » — le point 2 du
+  chantier (le droit de déclencher) refermé ; la réconciliation avec
+  le passe-outre de D422 consignée. rights.md mis au niveau.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -815,6 +815,10 @@ documentation) :
 | D692 | **La famille authentication** (la 8e — referme D418/D642) : le contrat `challenge()`/`verify(preuve)` aux deux visages (l'utilisateur → la session ; l'API → la preuve au porteur) ; les classes `local`/`azure_ad`/`sso` ; la session, le rapprochement (D82) et l'orchestration au moteur (D686) ; la garde du webhook appelle le même verify. | Validé. Voir §3.2c. |
 | D693 | **La session** : duration (l'inactivité au glissement, défaut 8h) et limit (l'absolu, défaut 7d) en settings dynamiques ; la borne SSO de l'IdP prime ; les sessions simultanées libres, la révocation administrateur ; l'API hors session ; la session ne fige jamais des droits. | « Je valide la session. » Voir §3.2c. |
 | D694 | **La vérification au début, le cache de droits** (précise D693) : la vérification au début d'une opération ou d'une sollicitation (l'acte entamé s'achève sous ses droits de départ) ; la latence minimisée par un cache invalidé à chaque modification de droits par les interfaces administrateur. | Voir §3.2c. |
+| D695 | **Le marquage rgpd:** (le volet RGPD, pièce 1) : `rgpd: personal \| sensitive \| consent` — l'article 9 porté (sensitive), le consentement tracé ; le modèle sait ce qui est personnel. | Voir §3.2c. |
+| D696 | **L'anonymisation par algorithme** (pièce 2) : la valeur construite à règle aléatoire, jamais dérivée de l'origine (l'exception : la longueur) — ni blanc ni haché ; les enregistrements ET les historiques modifiés. | Voir §3.2c. |
+| D697 | **anonymize, la 19e opération — le degré intrinsèque** (pièce 3) : l'usage limité à l'administration ; le principe posé — chaque opération du socle porte un degré intrinsèque d'autorisation (le plancher) ; l'inventaire des degrés flagué. | Voir §3.2c. |
+| D698 | **La rétention et le registre** (pièce 4 — boucle le volet) : la rétention échue s'anonymise d'office (D411/D696) ; le registre des traitements auto-documenté (D333/D645). | Voir §3.2c. |
 
 ---
 
@@ -6218,6 +6222,59 @@ la latence se paie par **un cache de droits** tenu par le moteur,
 administrateur** (l'affectation D341, les groupes, les modules) — le
 chemin d'écriture des droits étant exclusivement administratif, le
 cache n'a pas d'autre source d'invalidation à surveiller.
+
+**Le marquage rgpd: (D695 — le volet RGPD, pièce 1).** **« Porte
+l'article 9 du RGPD — `rgpd: personal | sensitive | consent`. »** —
+la facette du champ se nomme **`rgpd:`**, aux trois valeurs :
+**`personal`** (la donnée personnelle), **`sensitive`** (la donnée
+sensible — l'article 9 : la santé, les opinions, le régime
+renforcé), **`consent`** (le traitement assis sur le consentement).
+Le modèle sait qui voit (la confidentialité D25/D364) et désormais
+**ce qui est personnel** :
+
+```yaml
+fields:
+  name:       { type: text, rgpd: personal }
+  email:      { type: text, rgpd: personal }
+  blood_type: { type: text, rgpd: sensitive, confidentiality: private }
+  newsletter: { type: boolean, rgpd: consent }
+```
+
+**L'anonymisation — l'algorithme, jamais l'effacement simple (D696 —
+pièce 2).** **« L'anonymisation n'est pas un effacement simple. Il
+vise à construire une valeur répondant à un algorithme incluant une
+règle aléatoire non basée sur la valeur d'origine (peut-être à
+l'exception de la longueur de la chaîne). L'anonymisation consiste à
+modifier les valeurs de ces champs dans les enregistrements et dans
+les historiques. »** — la valeur de remplacement est **construite** :
+un algorithme à règle aléatoire, **jamais dérivée de la valeur
+d'origine** (l'exception admise : la longueur de la chaîne — la
+silhouette sans la personne) — ni un blanc (la trahison du vide), ni
+un haché (la ré-identification possible). La modification porte
+**les enregistrements et les historiques** (D168 — les instantanés
+compris) ; l'enregistrement demeure, ses agrégats et ses
+statistiques aussi.
+
+**anonymize, la dix-neuvième opération — et le degré intrinsèque
+d'autorisation (D697 — pièce 3).** **« L'opération anonymize peut
+être ajoutée avec une règle limitant son usage à l'administration.
+Cela signifie que les opérations définies dans le socle portent un
+degré intrinsèque d'autorisation (nous ne l'avons pas abordé
+encore). »** — `anonymize` entre au socle (le catalogue D574 passe à
+**dix-neuf**), l'usage limité à l'administration ; et le principe
+nouveau est posé : **chaque opération du socle porte un degré
+intrinsèque d'autorisation** — le plancher que la déclaration ne
+peut abaisser (anonymize = l'administration, restore = ? , migrate =
+?) — **l'inventaire des degrés est flagué** (le module
+d'administration, sujet 3, ou la fiche des opérations).
+
+**La rétention et le registre (D698 — pièce 4, « cela boucle le
+volet RGPD élégamment »).** La rétention rejoint l'historisation
+(D411) : la donnée marquée dont la rétention échoit **s'anonymise
+d'office** (l'algorithme D696) ; et **le registre des traitements
+s'auto-documente** (D333/D645) — les champs `rgpd:`, leur
+confidentialité, leur rétention, leurs connecteurs sortants : le
+document que la TPE peine à tenir, Syncytium le génère.
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -14173,6 +14230,14 @@ avant la synthèse Q16).
   administrateur, l'API hors session ; la vérification au début
   d'opération/sollicitation, le cache invalidé aux modifications
   administratives. rights.md mis au niveau.
+- **2026-08-16 (suite 56)** — **LE VOLET RGPD BOUCLÉ (D695–D698)** :
+  le marquage rgpd: personal|sensitive|consent (l'article 9),
+  l'anonymisation par algorithme aléatoire (enregistrements +
+  historiques), anonymize la 19e opération à l'usage administratif —
+  le degré intrinsèque d'autorisation des opérations posé (inventaire
+  flagué), la rétention qui anonymise d'office, le registre des
+  traitements auto-documenté. rights.md, hooks.md et types.md mis au
+  niveau.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -827,6 +827,7 @@ documentation) :
 | D704 | **L'audit au module d'administration** : une entité du module d'administration (porté par Syncytium — D666) ; les surfaces standard, le degré administrator, la rétention déclarée (D411). | Le module admin prend corps (sessions D693, audit D704). Voir §3.2c. |
 | D705 | **Le chiffrement en transit** : ce que Syncytium sert = HTTPS sans dérogation ; ce qu'il appelle = chiffré par défaut, l'exception déclarée au connecteur (`unencrypted:` en proposition — signalée, visible au describe). | « Je valide ce point. » Voir §3.2c. |
 | D706 | **Le chiffrement au repos — l'affaire du type** : le storage hors responsabilité de Syncytium (l'infrastructure) ; pas de facette — **un type chiffrant** (comme password) : le type qui a le pouvoir chiffre par ses fonctions de valeur (D683) et déclare ses capacités restantes. | Voir §3.2c. |
+| D707 | **Les clés obligatoirement chiffrées** (durcit D603 — solde le chiffrement) : les variables d'environnement (.env) jamais versionnées ; les commandes Syncytium chiffrent avant l'enregistrement (l'automatisation flaguée) ; le déchiffrement à l'usage ; le périmètre — les clés d'API, les mots de passe de connecteurs, les clés des types chiffrants (D706). | Voir §3.2c. |
 
 ---
 
@@ -6396,6 +6397,31 @@ deux arbitrages :
   type dit ses capacités, D579/D582, rien à documenter à part). Le
   technicien qui veut un texte chiffré prend le type chiffrant —
   le choix est un type, pas une option.
+
+**Les clés obligatoirement chiffrées — le patron unique (D707 —
+durcit D603, solde le chiffrement).** **« Les clés sont
+obligatoirement chiffrées. Elles sont stockées dans des variables
+d'environnement exploitées par Syncytium, jamais versionnées (cas
+d'un fichier .env). Le chiffrement est assuré par des commandes
+propres à Syncytium pour créer les clés chiffrées avant de les
+enregistrer dans l'environnement (à voir pour rendre cela
+automatique). Syncytium se charge alors de déchiffrer les valeurs à
+l'usage. Les clés concernées peuvent être les clés d'api, les mots
+de passe de connexion à un connecteur… »** — le « chiffrable » de
+D603 devient **obligatoire**, et le patron s'unifie pour tout
+secret :
+
+1. **la maison** : les variables d'environnement (le `.env`) —
+   **jamais versionnées** (D336), exploitées par Syncytium ;
+2. **la création** : **les commandes propres à Syncytium** chiffrent
+   la valeur *avant* son enregistrement dans l'environnement (la clé
+   dérivée environnement + machine — D603) ; *(flagué :
+   l'automatisation de ce geste)* ;
+3. **l'usage** : Syncytium déchiffre à l'usage — la valeur en clair
+   ne vit qu'en mémoire, le temps de l'appel ;
+4. **le périmètre** : les clés d'API, les mots de passe de
+   connecteurs… — et les clés des types chiffrants (D706) : un seul
+   patron pour tout ce qui est secret.
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -14384,6 +14410,13 @@ avant la synthèse Q16).
   responsabilité, le chiffrement = un pouvoir de type (comme
   password, les fonctions de valeur D683). rights.md mis au niveau.
   Reste le point 3 (les clés) — D603 rappelé à l'auteur.
+- **2026-08-16 (suite 61)** — **Les clés obligatoirement chiffrées
+  (D707)** : le patron unique — le .env jamais versionné, les
+  commandes Syncytium qui chiffrent avant l'enregistrement
+  (l'automatisation flaguée), le déchiffrement à l'usage ; le
+  chiffrement est soldé. Le chantier sécurité n'a plus de point
+  ouvert consigné — la clôture du sujet 2 attend la relecture de
+  l'auteur.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -813,6 +813,8 @@ documentation) :
 | D690 | **`rights.md` créé** : le huitième artefact préparatoire (Q58) — la sécurité et les droits consolidés (la doctrine P8, la confidentialité D25/D364, les droits d'action D196/D422–D423, l'audience anti-IDOR D70–D77, les groupes/modules, les connecteurs, la provenance) + les cinq points du chantier du sujet 2 ; aucun contenu nouveau. | À la demande de l'auteur — la méthode des connecteurs. |
 | D691 | **Les droits d'action couvrent les opérations** (referme le point 2 du chantier) : le socle (les 18) et les déclarées — le droit d'exécuter se déclare comme les autres droits d'action (D196) ; la réconciliation avec D422 : l'opération passe outre les allow d'état, le droit de la déclencher se contrôle. | Voir §3.2c. |
 | D692 | **La famille authentication** (la 8e — referme D418/D642) : le contrat `challenge()`/`verify(preuve)` aux deux visages (l'utilisateur → la session ; l'API → la preuve au porteur) ; les classes `local`/`azure_ad`/`sso` ; la session, le rapprochement (D82) et l'orchestration au moteur (D686) ; la garde du webhook appelle le même verify. | Validé. Voir §3.2c. |
+| D693 | **La session** : duration (l'inactivité au glissement, défaut 8h) et limit (l'absolu, défaut 7d) en settings dynamiques ; la borne SSO de l'IdP prime ; les sessions simultanées libres, la révocation administrateur ; l'API hors session ; la session ne fige jamais des droits. | « Je valide la session. » Voir §3.2c. |
+| D694 | **La vérification au début, le cache de droits** (précise D693) : la vérification au début d'une opération ou d'une sollicitation (l'acte entamé s'achève sous ses droits de départ) ; la latence minimisée par un cache invalidé à chaque modification de droits par les interfaces administrateur. | Voir §3.2c. |
 
 ---
 
@@ -6179,6 +6181,43 @@ de Syncytium, D619/D623) :
   client secret), le `describe` ; **le multi-connecteurs** : l'AD
   pour les internes, le local pour les clients (D77 — l'étanchéité
   par canal) ; la passerelle de D418 a son visage.
+
+**La session (D693 — « je valide la session »).** Les réglages aux
+settings de l'application (la forme D588, les durées D476), en mode
+`dynamic` — l'administrateur ajuste sans republier :
+
+```yaml
+settings:
+  application:
+    session:
+      duration: { mode: dynamic, type: duration, value: 8h }   # l'inactivité
+      limit:    { mode: dynamic, type: duration, value: 7d }   # l'absolu
+```
+
+— **`duration:`** l'inactivité au glissement (chaque action
+renouvelle, le délai passé déconnecte) ; **`limit:`** la borne
+absolue (la re-authentification obligatoire ; pour le SSO, la borne
+de l'IdP prime si plus courte) ; **les sessions simultanées libres**
+(le PC et la tablette — D15), **la révocation en acte
+d'administration** (les sessions d'un compte visibles et coupables —
+la pièce au module d'administration) ; la déconnexion manuelle
+toujours ; **l'API hors session** (D692) ; le changement
+d'affectations prend effet à la prochaine action — la session ne
+fige jamais des droits.
+
+**La vérification au début et le cache de droits (D694 — précise
+D693.4).** **« La vérification des actions s'effectue sur le début
+d'une opération ou d'une sollicitation. À Syncytium de minimiser le
+temps de latence de la vérification par un cache à mettre à jour à
+chaque modification de droits par les interfaces administrateur. »**
+— le moment est fixé : **le début** de l'opération ou de la
+sollicitation (jamais en cours de route — l'acte entamé s'achève
+sous les droits de son départ, la transaction D594 cohérente) ; et
+la latence se paie par **un cache de droits** tenu par le moteur,
+**invalidé à chaque modification de droits par les interfaces
+administrateur** (l'affectation D341, les groupes, les modules) — le
+chemin d'écriture des droits étant exclusivement administratif, le
+cache n'a pas d'autre source d'invalidation à surveiller.
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -14128,6 +14167,12 @@ avant la synthèse Q16).
   moteur, la garde du webhook branchée (D642 refermé), la passerelle
   D418 incarnée. hooks.md, connectors.md, glossaire.md et rights.md
   mis au niveau.
+- **2026-08-16 (suite 55)** — **La session et le cache de droits
+  (D693–D694)** : duration/limit en settings dynamiques, le
+  glissement et la borne, les sessions simultanées à révocation
+  administrateur, l'API hors session ; la vérification au début
+  d'opération/sollicitation, le cache invalidé aux modifications
+  administratives. rights.md mis au niveau.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -825,6 +825,8 @@ documentation) :
 | D702 | **Le grain de l'audit des lectures** : une ligne par lecture en masse de l'entité parente ou par transaction — le nombre d'éléments concernés, jamais une ligne par enregistrement ; la volumétrie à l'échelle de l'acte. | Voir §3.2c. |
 | D703 | **La propriété trace:** : le défaut automatique (rgpd: sensitive audité d'office) + `trace: audit` (l'opt-in) + **`trace: limited`** (l'exclusion — le mot de passe, la clé jamais tracés, D463/D603). | Voir §3.2c. |
 | D704 | **L'audit au module d'administration** : une entité du module d'administration (porté par Syncytium — D666) ; les surfaces standard, le degré administrator, la rétention déclarée (D411). | Le module admin prend corps (sessions D693, audit D704). Voir §3.2c. |
+| D705 | **Le chiffrement en transit** : ce que Syncytium sert = HTTPS sans dérogation ; ce qu'il appelle = chiffré par défaut, l'exception déclarée au connecteur (`unencrypted:` en proposition — signalée, visible au describe). | « Je valide ce point. » Voir §3.2c. |
+| D706 | **Le chiffrement au repos — l'affaire du type** : le storage hors responsabilité de Syncytium (l'infrastructure) ; pas de facette — **un type chiffrant** (comme password) : le type qui a le pouvoir chiffre par ses fonctions de valeur (D683) et déclare ses capacités restantes. | Voir §3.2c. |
 
 ---
 
@@ -6366,6 +6368,34 @@ l'audit se déclare comme toute historisation (D411). Le module
 d'administration prend corps pièce à pièce : la révocation des
 sessions (D693), l'audit (D704) — sa description complète attend le
 sujet 3.
+
+**Le chiffrement en transit (D705 — « je valide ce point »).** Tout
+ce que Syncytium **sert** (l'IHM, les API, les routes webhook D640)
+est HTTPS — obligatoire, sans dérogation. Tout ce que Syncytium
+**appelle** (les huit familles) exige le transport chiffré **par
+défaut** ; l'exception se déclare au connecteur *(l'écriture en
+proposition :* `unencrypted: true` *)* — signalée par l'ingestion,
+visible au `describe()` : expliciter plutôt que subir en silence.
+
+**Le chiffrement au repos — l'affaire du type (D706 — amende ma
+proposition).** **« Le chiffrement du storage n'est pas de la
+responsabilité de Syncytium. Une valeur encrypted serait plutôt un
+type (comme password). C'est le type qui gère le chiffrement — pas
+tous les types, juste ceux qui ont le pouvoir de le faire. »** —
+deux arbitrages :
+
+- **le storage hors responsabilité** : le TDE, le disque chiffré —
+  l'infrastructure et la classe, jamais le moteur (la recommandation
+  d'exploitation, rien de plus) ;
+- **pas de facette `encrypted:` — un type** : le chiffrement est
+  **un pouvoir de type** (le `password` D463 montre la voie) —
+  certains types chiffrent, les autres non ; les fonctions de valeur
+  du visiteur (D683) portent le chiffre à l'écriture et le déchiffre
+  à la lecture, et **le type déclare ce qu'il sait encore faire**
+  (la recherche stricte au mieux, le tri perdu — la signature du
+  type dit ses capacités, D579/D582, rien à documenter à part). Le
+  technicien qui veut un texte chiffré prend le type chiffrant —
+  le choix est un type, pas une option.
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -14348,6 +14378,12 @@ avant la synthèse Q16).
   complément du défaut automatique rgpd: sensitive ; l'entité
   d'audit au module d'administration. rights.md et types.md mis au
   niveau.
+- **2026-08-16 (suite 60)** — **Le chiffrement (D705–D706)** : le
+  transit validé (servi = HTTPS sans dérogation ; appelé = chiffré
+  par défaut, l'exception déclarée) ; le repos — le storage hors
+  responsabilité, le chiffrement = un pouvoir de type (comme
+  password, les fonctions de valeur D683). rights.md mis au niveau.
+  Reste le point 3 (les clés) — D603 rappelé à l'auteur.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -822,6 +822,9 @@ documentation) :
 | D699 | **Le degré intrinsèque au contrat, porté par le groupe** (solde D697) : le contrat des opérations le déclare ; user \| manager \| administrator ; le groupe d'utilisateurs porte le degré (`degree:` en proposition, défaut user) ; **l'appartenance à un groupe est obligatoire pour utiliser l'application**. | Voir §3.2c. |
 | D700 | **allow: aux groupes** (complète D423/D691) : le verbe ou l'opération accepte la liste des groupes autorisés, en plus de l'expression ; le degré intrinsèque reste le plancher — le plus exigeant l'emporte. | Voir §3.2c. |
 | D701 | **L'inventaire des dix-neuf planchers validé** : user (le quotidien — 14 opérations), manager (import, report), administrator (restore, migrate, anonymize). | « Je valide l'inventaire. » L'exemple détaillé dans rights.md. Voir §3.2c. |
+| D702 | **Le grain de l'audit des lectures** : une ligne par lecture en masse de l'entité parente ou par transaction — le nombre d'éléments concernés, jamais une ligne par enregistrement ; la volumétrie à l'échelle de l'acte. | Voir §3.2c. |
+| D703 | **La propriété trace:** : le défaut automatique (rgpd: sensitive audité d'office) + `trace: audit` (l'opt-in) + **`trace: limited`** (l'exclusion — le mot de passe, la clé jamais tracés, D463/D603). | Voir §3.2c. |
+| D704 | **L'audit au module d'administration** : une entité du module d'administration (porté par Syncytium — D666) ; les surfaces standard, le degré administrator, la rétention déclarée (D411). | Le module admin prend corps (sessions D693, audit D704). Voir §3.2c. |
 
 ---
 
@@ -6330,6 +6333,39 @@ l'inventaire »).** La table gravée :
 D238) ; la restauration (D174), la migration (D667) et
 l'anonymisation (D697) à l'administration. L'exemple détaillé porté
 dans rights.md (demande de l'auteur).
+
+**L'audit des lectures — le grain de la trace (D702).** **« Tout
+tracer n'est pas envisageable. La trace à la lecture en masse de
+l'entité parente, ou à la transaction, avec des informations portant
+sur le nombre d'éléments concernés. Cela limitera la volumétrie. »**
+— le grain est arrêté : **une ligne d'audit par lecture en masse de
+l'entité parente ou par transaction** — qui, quand, quoi (l'entité,
+le périmètre), par où, et **le nombre d'éléments concernés** —
+jamais une ligne par enregistrement : la volumétrie reste à
+l'échelle de l'acte, pas de la donnée.
+
+**La propriété trace: — audit et limited (D703).** Le défaut
+automatique validé (« une belle mécanique ») — **ce qui est `rgpd:
+sensitive` s'audite d'office** — et la propriété **`trace:`** le
+complète aux deux sens :
+
+- **`trace: audit`** — l'opt-in : le champ tracé au-delà du défaut
+  automatique ;
+- **`trace: limited`** — l'exclusion : le champ **écarté de toute
+  trace** pour des raisons de confidentialité — « un mot de passe ou
+  une clé ne doivent pas être tracés » (l'écho des garanties du
+  `password` D463 et des secrets D603 : la valeur sensible
+  n'apparaît dans aucun journal, aucun rapport, aucun audit).
+
+**L'audit au module d'administration (D704).** **« L'audit est porté
+dans une entité du module d'administration. »** — pas un module
+dédié : **le module d'administration** (porté par Syncytium — le
+patron D666) accueille l'entité d'audit ; les surfaces standard la
+consultent (le degré `administrator` — D699/D701), la rétention de
+l'audit se déclare comme toute historisation (D411). Le module
+d'administration prend corps pièce à pièce : la révocation des
+sessions (D693), l'audit (D704) — sa description complète attend le
+sujet 3.
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -14305,6 +14341,13 @@ avant la synthèse Q16).
   (D701)** : user/manager/administrator répartis sur les 19 ;
   l'exemple détaillé porté dans rights.md (qui peut quoi — la
   composition plancher × allow). L'audit des lectures s'ouvre.
+- **2026-08-16 (suite 59)** — **L'audit des lectures soldé
+  (D702–D704)** : le grain à l'acte (la masse ou la transaction, le
+  nombre d'éléments — jamais l'enregistrement) ; trace: audit
+  (l'opt-in) et trace: limited (l'exclusion — mot de passe, clé) en
+  complément du défaut automatique rgpd: sensitive ; l'entité
+  d'audit au module d'administration. rights.md et types.md mis au
+  niveau.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -100,11 +100,13 @@ documentation) :
    mapping/, les migrations déclarées, le module de suivi historisé,
    `migrate` la 18e opération, le versionnement plein, le
    différentiel par comparaison) ;
-2. **la sécurité et les droits** — **ouvert** (rights.md — D690) :
-   l'acquis consolidé ; les cinq points au chantier —
-   l'authentification (D418/D633/D642), le droit de déclencher, le
-   RGPD (la tension avec l'historisation D168), l'audit des
-   lectures, le chiffrement ;
+2. **la sécurité et les droits** — **soldé** (rights.md — D690 ;
+   « ces 2 commandes complètent la partie sécurité », D708) :
+   l'authentification (la famille D692, les 4 volets, la session
+   D693–D694), les droits étendus aux opérations (D691), le degré
+   intrinsèque à l'inventaire validé (D697/D699–D701), le RGPD
+   (D695–D698), l'audit des lectures (D702–D704), le chiffrement
+   (D705–D708) ;
 3. **l'administration et l'exploitation** — à ouvrir ; le module
    d'administration jamais décrit, la télémétrie (Q12–Q13) ;
 4. **la migration et les versions** — largement soldée : le mapping
@@ -14438,6 +14440,9 @@ avant la synthèse Q16).
   commandes consignées — le chiffrement vers le .env, le
   déchiffrement de vérification ; la partie sécurité complétée.
   rights.md mis au niveau.
+- **2026-08-16 (suite 63)** — **LE SUJET 2 (LA SÉCURITÉ ET LES
+  DROITS) EST SOLDÉ** (D690–D708) — le §1.2 mis au niveau. Reste le
+  sujet 3 : l'administration et l'exploitation.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -812,6 +812,7 @@ documentation) :
 | D689 | **Le curseur en lecture** (complète D688) : read() retourne un curseur, pas une liste évaluée — le lazy loading, le traitement en masse au suivi de progression ; le curseur convertit chaque ligne en un enregistrement reflétant la description des champs de l'entité (D683/D687), au fil du parcours. | L'écriture en lots, la lecture au curseur. Voir §3.2c. |
 | D690 | **`rights.md` créé** : le huitième artefact préparatoire (Q58) — la sécurité et les droits consolidés (la doctrine P8, la confidentialité D25/D364, les droits d'action D196/D422–D423, l'audience anti-IDOR D70–D77, les groupes/modules, les connecteurs, la provenance) + les cinq points du chantier du sujet 2 ; aucun contenu nouveau. | À la demande de l'auteur — la méthode des connecteurs. |
 | D691 | **Les droits d'action couvrent les opérations** (referme le point 2 du chantier) : le socle (les 18) et les déclarées — le droit d'exécuter se déclare comme les autres droits d'action (D196) ; la réconciliation avec D422 : l'opération passe outre les allow d'état, le droit de la déclencher se contrôle. | Voir §3.2c. |
+| D692 | **La famille authentication** (la 8e — referme D418/D642) : le contrat `challenge()`/`verify(preuve)` aux deux visages (l'utilisateur → la session ; l'API → la preuve au porteur) ; les classes `local`/`azure_ad`/`sso` ; la session, le rapprochement (D82) et l'orchestration au moteur (D686) ; la garde du webhook appelle le même verify. | Validé. Voir §3.2c. |
 
 ---
 
@@ -6147,6 +6148,37 @@ d'état de l'entité** (le promote écrit un enregistrement que l'état
 fige — l'acte porte sa légitimité), mais **le droit de déclencher
 l'opération** relève des droits d'action (D196/D691) : on contrôle
 qui appuie, pas ce que l'acte a le droit d'écrire.
+
+**La famille authentication (D692 — ouvre le point 1 du chantier et
+referme D418/D642).** Validé (« je valide ») — **la huitième famille
+de connecteur**, créée par le moteur (l'extension du jeu = l'affaire
+de Syncytium, D619/D623) :
+
+- **le contrat en deux gestes** : **`challenge()`** — comment
+  demander l'identité (le formulaire login/mdp, la redirection SSO,
+  le schéma du 401 pour l'API) — et **`verify(preuve)`** — juger la
+  preuve reçue (le couple saisi, le ticket au retour de redirection,
+  **le jeton porté par la requête**) : tous les chemins finissent en
+  une identité vérifiée ;
+- **les deux visages** : l'utilisateur (le défi interactif → la
+  session) et **l'API** (la preuve au porteur — chaque requête la
+  porte, pas de session) — le 401/Authorization de HTTP est
+  lui-même un défi/preuve ;
+- **les trois classes** : `local` (le haché vérifié par Syncytium,
+  les clés d'API des comptes techniques), `azure_ad` (le bind vers
+  l'annuaire, le bearer Entra), `sso` (la redirection OIDC, la
+  signature du jeton) — chaque classe déclare ce qu'elle sait
+  vérifier ;
+- **l'orchestration au moteur** (D686) : la session (la durée, le
+  renouvellement), l'écran de connexion, le rapprochement du compte
+  (D82 — la clé d'unicité par connecteur), la typologie des comptes
+  (D77) ; **la garde du webhook (D642) appelle ce même `verify`** —
+  le flag refermé, rien de dédié ;
+- **le socle commun hérité** : le `ping()` (la santé de l'IdP),
+  l'`onerror` (la maintenance si le SSO tombe), les secrets (le
+  client secret), le `describe` ; **le multi-connecteurs** : l'AD
+  pour les internes, le local pour les clients (D77 — l'étanchéité
+  par canal) ; la passerelle de D418 a son visage.
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -14090,6 +14122,12 @@ avant la synthèse Q16).
   opérations du socle et les opérations déclarées » — le point 2 du
   chantier (le droit de déclencher) refermé ; la réconciliation avec
   le passe-outre de D422 consignée. rights.md mis au niveau.
+- **2026-08-16 (suite 54)** — **La famille authentication (D692)** :
+  la 8e famille — challenge()/verify(preuve), les deux visages
+  (utilisateur/API), les classes local/azure_ad/sso, la session au
+  moteur, la garde du webhook branchée (D642 refermé), la passerelle
+  D418 incarnée. hooks.md, connectors.md, glossaire.md et rights.md
+  mis au niveau.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -821,6 +821,7 @@ documentation) :
 | D698 | **La rétention et le registre** (pièce 4 — boucle le volet) : la rétention échue s'anonymise d'office (D411/D696) ; le registre des traitements auto-documenté (D333/D645). | Voir §3.2c. |
 | D699 | **Le degré intrinsèque au contrat, porté par le groupe** (solde D697) : le contrat des opérations le déclare ; user \| manager \| administrator ; le groupe d'utilisateurs porte le degré (`degree:` en proposition, défaut user) ; **l'appartenance à un groupe est obligatoire pour utiliser l'application**. | Voir §3.2c. |
 | D700 | **allow: aux groupes** (complète D423/D691) : le verbe ou l'opération accepte la liste des groupes autorisés, en plus de l'expression ; le degré intrinsèque reste le plancher — le plus exigeant l'emporte. | Voir §3.2c. |
+| D701 | **L'inventaire des dix-neuf planchers validé** : user (le quotidien — 14 opérations), manager (import, report), administrator (restore, migrate, anonymize). | « Je valide l'inventaire. » L'exemple détaillé dans rights.md. Voir §3.2c. |
 
 ---
 
@@ -6315,6 +6316,20 @@ operations:
 Le degré intrinsèque reste le plancher : un `allow:` généreux
 n'abaisse jamais le degré exigé par le contrat — les deux se
 composent, le plus exigeant l'emporte.
+
+**L'inventaire des dix-neuf planchers (D701 — « je valide
+l'inventaire »).** La table gravée :
+
+| le degré | les opérations |
+|---|---|
+| `user` | `create` · `read` · `update` · `delete` · `duplicate` · `promote` · `demote` · `generate` · `download` · `print` · `send` · `export` · `notify` · `refresh` |
+| `manager` | `import` · `report` |
+| `administrator` | `restore` · `migrate` · `anonymize` |
+
+— le quotidien aux droits déclarés ; l'import déjà réservé (D211/
+D238) ; la restauration (D174), la migration (D667) et
+l'anonymisation (D697) à l'administration. L'exemple détaillé porté
+dans rights.md (demande de l'auteur).
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -14286,6 +14301,10 @@ avant la synthèse Q16).
   l'emporte. L'inventaire des 19 planchers reste à valider.
   rights.md, hooks.md et glossaire.md mis au niveau. **La 700e
   décision.**
+- **2026-08-16 (suite 58)** — **L'inventaire des planchers validé
+  (D701)** : user/manager/administrator répartis sur les 19 ;
+  l'exemple détaillé porté dans rights.md (qui peut quoi — la
+  composition plancher × allow). L'audit des lectures s'ouvre.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -819,6 +819,8 @@ documentation) :
 | D696 | **L'anonymisation par algorithme** (pièce 2) : la valeur construite à règle aléatoire, jamais dérivée de l'origine (l'exception : la longueur) — ni blanc ni haché ; les enregistrements ET les historiques modifiés. | Voir §3.2c. |
 | D697 | **anonymize, la 19e opération — le degré intrinsèque** (pièce 3) : l'usage limité à l'administration ; le principe posé — chaque opération du socle porte un degré intrinsèque d'autorisation (le plancher) ; l'inventaire des degrés flagué. | Voir §3.2c. |
 | D698 | **La rétention et le registre** (pièce 4 — boucle le volet) : la rétention échue s'anonymise d'office (D411/D696) ; le registre des traitements auto-documenté (D333/D645). | Voir §3.2c. |
+| D699 | **Le degré intrinsèque au contrat, porté par le groupe** (solde D697) : le contrat des opérations le déclare ; user \| manager \| administrator ; le groupe d'utilisateurs porte le degré (`degree:` en proposition, défaut user) ; **l'appartenance à un groupe est obligatoire pour utiliser l'application**. | Voir §3.2c. |
+| D700 | **allow: aux groupes** (complète D423/D691) : le verbe ou l'opération accepte la liste des groupes autorisés, en plus de l'expression ; le degré intrinsèque reste le plancher — le plus exigeant l'emporte. | Voir §3.2c. |
 
 ---
 
@@ -6275,6 +6277,44 @@ d'office** (l'algorithme D696) ; et **le registre des traitements
 s'auto-documente** (D333/D645) — les champs `rgpd:`, leur
 confidentialité, leur rétention, leurs connecteurs sortants : le
 document que la TPE peine à tenir, Syncytium le génère.
+
+**Le degré intrinsèque — au contrat, porté par le groupe (D699 —
+solde le flag de D697).** **« Le degré intrinsèque est porté par le
+contrat des opérations. Les 3 valeurs user | manager | administrator
+couvrent le besoin. Un groupe d'utilisateurs porte ce degré. Un
+utilisateur, pour utiliser l'application, est forcément associé à un
+groupe d'utilisateurs. »** — quatre pièces :
+
+- **le degré vit au contrat de l'opération** (la signature du hook —
+  comme execute/confirm/commit/rollback, D595) : chaque opération du
+  socle et chaque hook d'opération le déclare ;
+- **les trois valeurs** : `user` · `manager` · `administrator` ;
+- **le groupe porte le degré** — pas une qualité du compte : le
+  groupe d'utilisateurs (D414) déclare son degré *(l'écriture en
+  proposition :* `degree:` *dans groups.yml, défaut `user` —*
+  `admins: { degree: administrator }`*)* ; l'utilisateur atteint le
+  degré de son meilleur groupe (la multi-appartenance D414) ;
+- **l'appartenance obligatoire** : « un utilisateur, pour utiliser
+  l'application, est forcément associé à un groupe » — le compte
+  sans groupe n'entre pas (le fail-closed D71 jusqu'à la porte).
+
+**allow: aux groupes (D700 — complète D423/D691).** **« allow:
+complète en précisant les groupes d'utilisateurs autorisés. »** — la
+forme libre s'enrichit : le verbe (ou l'opération) accepte **la
+liste des groupes autorisés**, en plus de l'expression (D90) :
+
+```yaml
+allow:
+  update: locked = false          # l'expression (D423)
+  delete: [admins]                # les groupes autorisés (D700)
+operations:
+  archive:
+    allow: [managers, admins]     # le droit de déclencher (D691/D700)
+```
+
+Le degré intrinsèque reste le plancher : un `allow:` généreux
+n'abaisse jamais le degré exigé par le contrat — les deux se
+composent, le plus exigeant l'emporte.
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -14238,6 +14278,14 @@ avant la synthèse Q16).
   flagué), la rétention qui anonymise d'office, le registre des
   traitements auto-documenté. rights.md, hooks.md et types.md mis au
   niveau.
+- **2026-08-16 (suite 57)** — **Le degré intrinsèque et allow: aux
+  groupes (D699–D700)** : le degré au contrat des opérations
+  (user/manager/administrator), le groupe le porte (degree: en
+  proposition), l'appartenance obligatoire ; allow: précise les
+  groupes autorisés — le plancher demeure, le plus exigeant
+  l'emporte. L'inventaire des 19 planchers reste à valider.
+  rights.md, hooks.md et glossaire.md mis au niveau. **La 700e
+  décision.**
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -99,9 +99,9 @@ connector: { storage: main_db, from: legacy_db }
   cas de l'affichage d'une carte, nous pouvons définir plusieurs
   connecteurs et, en fonction de l'écran, utiliser l'un ou l'autre ».
 
-## Les sept familles (D623) et le catalogue de base (D604)
+## Les huit familles (D623/D692) et le catalogue de base (D604)
 
-**Le jeu est clos** (D619) — sept familles, « route est un exemple
+**Le jeu est clos** (D619) — huit familles, « route est un exemple
 d'extension ultérieure » (l'extension = l'affaire du moteur, jamais
 du hook) ; **la famille contraint le contrat** (D620), la conformité
 d'une classe vérifiée au chargement :
@@ -115,6 +115,7 @@ d'une classe vérifiée au chargement :
 | `location` | le géocodage | ban (Addok), nominatim | D294 |
 | `webhook` | **« un point d'entrée dans les différents appels d'api versionnés »** — get, put, post, delete (D609) | — | D623–D624 |
 | `siren` | la vérification des identifiants | — | D611/D623 |
+| `authentication` | l'identité — l'utilisateur et l'API (D692) | local, azure_ad, sso | D418/D692 |
 
 *(La reprise n'est pas une famille : le connecteur de reprise
 (D175–D179) s'appuie sur les familles existantes — le storage en
@@ -243,6 +244,26 @@ le type `geolocation` du modèle (D391) et l'inverse ; **le type porte
 les coordonnées longitude/latitude et/ou l'adresse postale
 normalisée** (D638) — geocode rend le point ET l'adresse mise au
 propre ; `ban`/`nominatim` (D294) les implémentent.
+
+### `authentication` (D692)
+
+**Le contrat en deux gestes**, aux deux visages :
+
+| le geste | l'utilisateur (interactif) | l'API (au porteur) |
+|---|---|---|
+| `challenge()` | le formulaire login/mdp, ou la redirection SSO | le schéma attendu (le 401 — Bearer, ApiKey…) |
+| `verify(preuve)` | le couple saisi (local : le haché ; azure_ad : le bind), le ticket au retour (sso) | **le jeton porté par la requête** — la clé d'API, le bearer |
+
+Tous les chemins finissent en **une identité vérifiée**, rapprochée
+du compte (D82 — la clé d'unicité par connecteur) ; **la session,
+l'écran de connexion et l'orchestration vivent au moteur** (D686) ;
+l'API ne porte pas de session — chaque requête porte sa preuve (le
+compte technique D77). **La garde du webhook (D642) appelle ce même
+`verify`** — rien de dédié. Les classes : `local` (le haché, les
+clés d'API), `azure_ad` (le bind, le bearer Entra), `sso` (l'OIDC,
+la signature du jeton) — chaque classe déclare ce qu'elle sait
+vérifier ; le multi-connecteurs sert l'étanchéité par canal (D77 —
+l'AD pour les internes, le local pour les clients).
 
 ### `siren` (D639)
 

--- a/docs/glossaire.md
+++ b/docs/glossaire.md
@@ -59,9 +59,9 @@ entrants et ses sortants — la lecture et l'écriture selon les
 spécificités de sa famille. Il est **global** (aucune déclinaison par
 module ni entité) et **déclaré à l'environnement** : chaque
 environnement les siens, la complétude vérifiée à l'ingestion. **Son
-type est sa famille — et son contrat** : sept familles closes
+type est sa famille — et son contrat** : huit familles closes
 (`storage`, `smtp`, `file`, `directory`, `location`, `webhook`,
-`siren`) dont chacune contraint les méthodes ; sa **classe**
+`siren`, `authentication`) dont chacune contraint les méthodes ; sa **classe**
 (`postgresql`, `ban`, `smtp_std`…) remplit le contrat. Toute classe
 implémente le socle commun : `initialize`/`release`,
 `connect`/`disconnect`, `ping()` (le statut, la fréquence à

--- a/docs/glossaire.md
+++ b/docs/glossaire.md
@@ -125,7 +125,10 @@ vraie), le stockage physique, l'affichage, la forme d'API ou la nature du champ 
 **Groupe d'utilisateurs** (`group`, `groups.yml`) — Un ensemble nommé de personnes,
 brique des droits : la confidentialité, la visibilité d'un historique,
 les destinataires d'un rapport. Un groupe peut en contenir d'autres. Syncytium ne gère pas dans sa configuration les liens directs avec les utilisateurs. Syncytium manipule dans sa configuration des groupes. Les utilisateurs sont associés par un technicien ou par une passerelle avec un système d'authentification.
-*Ex. : `managers: { groups: [accounting, sales_team] }`.* *(D26/D414)*
+Le groupe porte **le degré d'autorisation** (`degree:` — `user`,
+`manager` ou `administrator`, D699) ; l'appartenance à un groupe est
+**obligatoire** pour utiliser l'application.
+*Ex. : `managers: { degree: manager, groups: [accounting, sales_team] }`.* *(D26/D414/D699)*
 
 **Historisation** (`history`) — La mémoire d'une entité : chaque
 modification photographie l'agrégat entier. On en règle la profondeur :

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -270,13 +270,17 @@ fields:
 
 Ajoute **une classe de connecteur** — la passerelle globale, déclarée
 à l'environnement (`environments/<env>.yml` — D603/D617, aucune
-déclinaison). **Les sept familles sont closes** (D619/D623) :
+déclinaison). **Les huit familles sont closes** (D619/D623/D692) :
 `storage` (les bases — et les formats csv/xml/json des exports et
 imports, D636), `smtp`, `file` (le guetteur), `directory` (l'AD
 Azure), `location` (le géocodage), `webhook` (les entrées servies),
-`siren` — « il n'existe pas de hook de famille : le hook porte sur
-l'implémentation d'une famille » (une classe, jamais un contrat
-neuf ; `route` attend une version ultérieure du moteur).
+`siren`, **`authentication`** (D692 — le contrat
+`challenge()`/`verify(preuve)` aux deux visages, l'utilisateur et
+l'API ; les classes `local`/`azure_ad`/`sso` ; la session et le
+rapprochement du compte au moteur — D82/D686) — « il n'existe pas de
+hook de famille : le hook porte sur l'implémentation d'une famille »
+(une classe, jamais un contrat neuf ; `route` attend une version
+ultérieure du moteur).
 
 **Le contrat par famille (D605/D620)** : « chaque famille a ses
 propres méthodes et fonctions » — la famille contraint le contrat, la

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -161,9 +161,12 @@ code » (D570). Les 19 opérations de socle (D574, `migrate` D667,
 `update`, `delete`, `duplicate`, `promote`, `demote`, `generate`,
 `download`, `print`, `send`, `export`, `import`, `report`,
 `restore`, `notify`, `refresh`, `migrate`, `anonymize`. **Chaque
-opération du socle porte un degré intrinsèque d'autorisation**
-(D697 — le plancher que la déclaration ne peut abaisser :
-`anonymize` = l'administration ; l'inventaire des degrés flagué).
+opération porte un degré intrinsèque d'autorisation, déclaré à son
+contrat** (D697/D699 — `user` | `manager` | `administrator`, le
+plancher que la déclaration ne peut abaisser ; le groupe
+d'utilisateurs porte le degré, l'appartenance à un groupe est
+obligatoire ; `allow:` précise les groupes autorisés — D700, le plus
+exigeant l'emporte).
 
 **Le contrat — l'objet aux quatre fonctions (D595) :**
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -156,12 +156,14 @@ fields:
 
 Ajoute **une opération** — « une opération ne se construit pas dans
 la configuration : elle se construit toujours à l'aide d'un hook de
-code » (D570). Les 18 opérations de socle (D574, `migrate` ajouté
-par D667) sont les hooks
-embarqués : `create`, `read`, `update`, `delete`, `duplicate`,
-`promote`, `demote`, `generate`, `download`, `print`, `send`,
-`export`, `import`, `report`, `restore`, `notify`, `refresh`,
-`migrate` (D667).
+code » (D570). Les 19 opérations de socle (D574, `migrate` D667,
+`anonymize` D697) sont les hooks embarqués : `create`, `read`,
+`update`, `delete`, `duplicate`, `promote`, `demote`, `generate`,
+`download`, `print`, `send`, `export`, `import`, `report`,
+`restore`, `notify`, `refresh`, `migrate`, `anonymize`. **Chaque
+opération du socle porte un degré intrinsèque d'autorisation**
+(D697 — le plancher que la déclaration ne peut abaisser :
+`anonymize` = l'administration ; l'inventaire des degrés flagué).
 
 **Le contrat — l'objet aux quatre fonctions (D595) :**
 

--- a/docs/rights.md
+++ b/docs/rights.md
@@ -319,8 +319,25 @@ fields:
   (D683) et déclare ce qu'il sait encore faire (la recherche
   stricte au mieux, le tri perdu — la signature du type D579/D582).
 
+## Les clés — le patron unique des secrets (D603/D707)
+
+**Les clés sont obligatoirement chiffrées** (D707 — le
+« chiffrable » de D603 durci) :
+
+1. **la maison** : les variables d'environnement (le `.env`) —
+   **jamais versionnées** (D336), exploitées par Syncytium ;
+2. **la création** : **les commandes propres à Syncytium** chiffrent
+   la valeur *avant* son enregistrement dans l'environnement (la clé
+   dérivée environnement + machine — D603) ; *(flagué :
+   l'automatisation de ce geste)* ;
+3. **l'usage** : Syncytium déchiffre à l'usage — la valeur en clair
+   ne vit qu'en mémoire, le temps de l'appel ;
+4. **le périmètre** : les clés d'API, les mots de passe de
+   connecteurs, les clés des types chiffrants (D706) — un seul
+   patron pour tout ce qui est secret.
+
 ## Les points ouverts — le chantier du sujet 2
 
-1. **les clés du chiffrement de type** (D706) — la dérivation (le
-   patron des secrets D603 ?) et la rotation (un acte
-   d'administration ?) — en discussion.
+Aucun point consigné — la clôture du sujet 2 attend la relecture de
+l'auteur (le flag mineur : l'automatisation de la commande de
+chiffrement, D707).

--- a/docs/rights.md
+++ b/docs/rights.md
@@ -126,14 +126,35 @@ persiste après la mort du connecteur (D178) ; l'import
 d'exploitation porte l'opérateur (D238) ; la trace des opérations
 est l'historisation elle-même (D429).
 
+## L'authentification (D692)
+
+**La famille de connecteur `authentication`** — la huitième : le
+contrat **`challenge()`/`verify(preuve)`**, la session et
+l'orchestration au moteur (D686), le rapprochement du compte par la
+clé d'unicité (D82). **Les quatre volets à porter** :
+
+1. **`local`** — le compte géré par Syncytium : le mot de passe
+   haché vérifié par le moteur ; le premier visage des comptes
+   clients (D77) ;
+2. **`azure_ad`** — l'annuaire : le bind vers l'AD Azure, le bearer
+   Entra — le pendant authentifiant du connecteur `directory`
+   (D633, la synchronisation restant à lui) ;
+3. **`sso`** — la délégation : la redirection OIDC, le ticket au
+   retour, la signature du jeton validée — l'utilisateur ne confie
+   jamais son secret à Syncytium ;
+4. **l'API** — la preuve au porteur : la clé d'API ou le bearer dans
+   chaque requête (le 401 en défi), le compte technique (D77), pas
+   de session ; **la garde du webhook (D642) appelle le même
+   `verify`**.
+
+La passerelle (D418) a son visage ; le multi-connecteurs sert
+l'étanchéité par canal (D77). Voir le contrat détaillé dans
+[connectors.md](connectors.md).
+
 ## Les points ouverts — le chantier du sujet 2
 
-1. **L'authentification** — les trois flags accumulés : la
-   passerelle (D418 — le lien utilisateur↔annuaire), les modes (le
-   compte local, l'AD via `directory`, le SSO ?), la session (la
-   durée, le renouvellement), les API (le jeton — le compte
-   technique D77), le mécanisme concret de la garde webhook (D642 —
-   la clé, le jeton, la signature ?) ;
+1. **la session** — les réglages fins (la durée, le renouvellement,
+   la déconnexion — des settings ?) ;
 2. **le RGPD** — les données personnelles marquées au modèle ? le
    droit à l'effacement face à l'historisation (D168) et à la
    provenance persistante (D178) ; la rétention ;

--- a/docs/rights.md
+++ b/docs/rights.md
@@ -180,11 +180,42 @@ settings:
   cache de droits**, invalidé à chaque modification de droits par
   les interfaces administrateur (D341).
 
+## Le RGPD (D695–D698)
+
+- **le marquage** (D695) : la facette **`rgpd:`** aux trois valeurs —
+  `personal` (la donnée personnelle), `sensitive` (l'article 9 — le
+  régime renforcé), `consent` (le traitement au consentement) :
+
+```yaml
+fields:
+  name:       { type: text, rgpd: personal }
+  blood_type: { type: text, rgpd: sensitive, confidentiality: private }
+  newsletter: { type: boolean, rgpd: consent }
+```
+
+- **l'effacement = l'anonymisation** (D696) : la valeur de
+  remplacement est **construite par un algorithme à règle
+  aléatoire, jamais dérivée de l'origine** (l'exception admise : la
+  longueur de la chaîne) — ni un blanc, ni un haché ; la
+  modification porte **les enregistrements et les historiques**
+  (D168) — l'enregistrement demeure, la personne disparaît ; la
+  provenance (D178), technique, survit ;
+- **`anonymize`, la dix-neuvième opération du socle** (D697) :
+  l'usage limité à l'administration — et le principe posé : **chaque
+  opération du socle porte un degré intrinsèque d'autorisation** (le
+  plancher que la déclaration ne peut abaisser) ; l'inventaire des
+  degrés est flagué ;
+- **la rétention** (D698) : la donnée marquée dont la rétention
+  échoit (l'écriture de l'historisation — D411) **s'anonymise
+  d'office** ;
+- **le registre des traitements auto-documenté** (D698 —
+  D333/D645) : les champs `rgpd:`, leur confidentialité, leur
+  rétention, leurs connecteurs sortants — généré, jamais rédigé.
+
 ## Les points ouverts — le chantier du sujet 2
 
-1. **le RGPD** — les données personnelles marquées au modèle ? le
-   droit à l'effacement face à l'historisation (D168) et à la
-   provenance persistante (D178) ; la rétention ;
+1. **le degré intrinsèque d'autorisation** (D697) — l'inventaire
+   des planchers des dix-neuf opérations du socle ;
 2. **l'audit** — la trace des écritures existe ; l'audit des
    **lectures** (qui a consulté quoi), celui des actes
    d'administration, la surface qui le consulte ;

--- a/docs/rights.md
+++ b/docs/rights.md
@@ -278,9 +278,32 @@ allow:
 le fail-closed jusqu'à la porte) ; la vérification joue **au début**
 de l'opération, servie par le cache de droits (D694).
 
+## L'audit des lectures (D702–D704)
+
+- **le grain : l'acte, jamais l'enregistrement** (D702) — une ligne
+  d'audit **par lecture en masse de l'entité parente ou par
+  transaction** : qui, quand, quoi (l'entité, le périmètre), par où
+  (l'écran, l'export, l'impression, l'API, le connecteur), et **le
+  nombre d'éléments concernés** — la volumétrie limitée ;
+- **le défaut automatique** (D703) : ce qui est `rgpd: sensitive`
+  (D695) s'audite d'office — rien à écrire ;
+- **la propriété `trace:`** (D703) — les deux compléments :
+  `trace: audit` (l'opt-in — le champ tracé au-delà du défaut) et
+  **`trace: limited`** (l'exclusion — le champ écarté de **toute**
+  trace : « un mot de passe ou une clé ne doivent pas être tracés »,
+  l'écho de D463/D603) ;
+- **la maison** (D704) : une entité du **module d'administration**
+  (porté par Syncytium — le patron D666) ; les surfaces standard la
+  consultent (le degré `administrator`), la rétention de l'audit se
+  déclare comme toute historisation (D411).
+
+```yaml
+fields:
+  blood_type: { type: text, rgpd: sensitive }   # audité d'office (D703)
+  notes:      { type: text, trace: audit }      # l'opt-in
+  api_key:    { type: password, trace: limited } # jamais tracé — nulle part
+```
+
 ## Les points ouverts — le chantier du sujet 2
 
-2. **l'audit** — la trace des écritures existe ; l'audit des
-   **lectures** (qui a consulté quoi), celui des actes
-   d'administration, la surface qui le consulte ;
-3. **le chiffrement** — au repos (le storage), en transit.
+1. **le chiffrement** — au repos (le storage), en transit.

--- a/docs/rights.md
+++ b/docs/rights.md
@@ -71,9 +71,14 @@ allow:
   delete: false
 ```
 
-L'absence = tout permis ; **les opérations passent outre** (D422 —
-l'acte déclaré porte sa propre légitimité) ; `read` absent = l'état
-masque.
+L'absence = tout permis ; `read` absent = l'état masque. **Les
+droits d'action couvrent les opérations du socle et les opérations
+déclarées** (D691) : le droit d'exécuter se déclare et se contrôle
+comme les autres droits d'action. La réconciliation avec le
+passe-outre (D422) : l'opération autorisée **passe outre les `allow`
+d'état** (l'acte porte sa légitimité — le promote écrit ce que
+l'état fige), mais **le droit de la déclencher** relève des droits
+d'action — on contrôle qui appuie, pas ce que l'acte écrit.
 
 ## L'audience et l'anti-IDOR (D70–D77, D144, D153)
 
@@ -129,13 +134,10 @@ est l'historisation elle-même (D429).
    durée, le renouvellement), les API (le jeton — le compte
    technique D77), le mécanisme concret de la garde webhook (D642 —
    la clé, le jeton, la signature ?) ;
-2. **le droit de déclencher** — D196 couvre les actions d'entité ;
-   le droit d'exécuter une opération déclarée (les 18 du socle, les
-   hooks) est-il entièrement couvert, ou manque-t-il un grain ?
-3. **le RGPD** — les données personnelles marquées au modèle ? le
+2. **le RGPD** — les données personnelles marquées au modèle ? le
    droit à l'effacement face à l'historisation (D168) et à la
    provenance persistante (D178) ; la rétention ;
-4. **l'audit** — la trace des écritures existe ; l'audit des
+3. **l'audit** — la trace des écritures existe ; l'audit des
    **lectures** (qui a consulté quoi), celui des actes
    d'administration, la surface qui le consulte ;
-5. **le chiffrement** — au repos (le storage), en transit.
+4. **le chiffrement** — au repos (le storage), en transit.

--- a/docs/rights.md
+++ b/docs/rights.md
@@ -304,6 +304,23 @@ fields:
   api_key:    { type: password, trace: limited } # jamais tracé — nulle part
 ```
 
+## Le chiffrement (D705–D706)
+
+- **en transit** (D705) : ce que Syncytium **sert** (l'IHM, les API,
+  les routes webhook) est **HTTPS sans dérogation** ; ce qu'il
+  **appelle** (les huit familles) est chiffré **par défaut** —
+  l'exception déclarée au connecteur (`unencrypted:` en
+  proposition), signalée par l'ingestion, visible au `describe()` ;
+- **au repos** (D706) : le chiffrement du storage (TDE, disque)
+  **n'est pas de la responsabilité de Syncytium** — l'infrastructure
+  et la classe ; et le chiffrement d'une valeur est **un pouvoir de
+  type** (comme `password` — D463) : pas de facette `encrypted:` —
+  le type qui a le pouvoir chiffre par ses fonctions de valeur
+  (D683) et déclare ce qu'il sait encore faire (la recherche
+  stricte au mieux, le tri perdu — la signature du type D579/D582).
+
 ## Les points ouverts — le chantier du sujet 2
 
-1. **le chiffrement** — au repos (le storage), en transit.
+1. **les clés du chiffrement de type** (D706) — la dérivation (le
+   patron des secrets D603 ?) et la rotation (un acte
+   d'administration ?) — en discussion.

--- a/docs/rights.md
+++ b/docs/rights.md
@@ -336,6 +336,20 @@ fields:
    connecteurs, les clés des types chiffrants (D706) — un seul
    patron pour tout ce qui est secret.
 
+**Les deux commandes** (D708) :
+
+```bash
+# chiffre la clé et l'enregistre dans .env (ou un autre fichier si nécessaire)
+syncytium encrypt DB_PASSWORD "le-mot-de-passe"
+
+# retourne la valeur chiffrée — le débogage, la vérification d'un service
+syncytium decrypt DB_PASSWORD
+```
+
+La clé de chiffrement étant dérivée de l'environnement **et de la
+machine** (D603), un `.env` copié ailleurs reste muet — le `decrypt`
+n'est utile qu'à qui a déjà la machine.
+
 ## Les points ouverts — le chantier du sujet 2
 
 Aucun point consigné — la clôture du sujet 2 attend la relecture de

--- a/docs/rights.md
+++ b/docs/rights.md
@@ -151,14 +151,41 @@ La passerelle (D418) a son visage ; le multi-connecteurs sert
 l'étanchéité par canal (D77). Voir le contrat détaillé dans
 [connectors.md](connectors.md).
 
+## La session (D693–D694)
+
+Les réglages aux settings de l'application (D588), en mode
+`dynamic` :
+
+```yaml
+settings:
+  application:
+    session:
+      duration: { mode: dynamic, type: duration, value: 8h }   # l'inactivité
+      limit:    { mode: dynamic, type: duration, value: 7d }   # l'absolu
+```
+
+- **`duration:`** — l'inactivité au glissement : chaque action
+  renouvelle, le délai passé déconnecte ;
+- **`limit:`** — la borne absolue : la re-authentification
+  obligatoire ; pour le SSO, la borne de l'IdP prime si plus
+  courte ;
+- **les sessions simultanées libres** (D15) — la révocation est un
+  acte d'administration (les sessions d'un compte visibles et
+  coupables) ; la déconnexion manuelle toujours ;
+- **l'API hors session** (D692) — chaque requête porte sa preuve ;
+- **la session ne fige jamais des droits** : la vérification
+  s'effectue **au début d'une opération ou d'une sollicitation**
+  (D694 — l'acte entamé s'achève sous les droits de son départ, la
+  transaction cohérente D594) ; la latence est minimisée par **un
+  cache de droits**, invalidé à chaque modification de droits par
+  les interfaces administrateur (D341).
+
 ## Les points ouverts — le chantier du sujet 2
 
-1. **la session** — les réglages fins (la durée, le renouvellement,
-   la déconnexion — des settings ?) ;
-2. **le RGPD** — les données personnelles marquées au modèle ? le
+1. **le RGPD** — les données personnelles marquées au modèle ? le
    droit à l'effacement face à l'historisation (D168) et à la
    provenance persistante (D178) ; la rétention ;
-3. **l'audit** — la trace des écritures existe ; l'audit des
+2. **l'audit** — la trace des écritures existe ; l'audit des
    **lectures** (qui a consulté quoi), celui des actes
    d'administration, la surface qui le consulte ;
-4. **le chiffrement** — au repos (le storage), en transit.
+3. **le chiffrement** — au repos (le storage), en transit.

--- a/docs/rights.md
+++ b/docs/rights.md
@@ -1,0 +1,141 @@
+# La sécurité et les droits de Syncytium
+
+Ce document rassemble **la nature et les exemples des échanges
+consignés sur la sécurité et les droits** — le huitième artefact
+préparatoire de la documentation (Q58, le domaine 6 — D602), après le
+[glossaire](glossaire.md), les [composants](composants.md), les
+[hooks](hooks.md), les [types](types.md), les
+[connecteurs](connectors.md) et le [mapping](mapping.md). Les
+décisions citées renvoient à la [conception](conception.md). Il
+consolide l'acquis (le pilier P8 — la sécurité par construction) et
+porte les points du chantier ouvert (le sujet 2 de la passe de
+complétude).
+
+## La doctrine
+
+- **La sécurité par construction** (P8) : les niveaux de
+  confidentialité emboîtés, l'audience au niveau ligne à identifiants
+  opaques, les droits d'action au modèle — jamais une couche ajoutée
+  après coup ;
+- **Restreindre, jamais étendre** (D190/D416) : un module restreint
+  la surface visible, il n'étend jamais les droits ;
+- **Masquer, ne jamais détruire** (D137/D141) : la suppression est
+  une désactivation ; l'effacement physique est l'exception tracée
+  (la reprise — D184) ;
+- **L'anti-oracle** (D144/D153) : l'interdit ne se devine pas — ni
+  par la navigation, ni par les messages, ni par les comptages ;
+- **Fail-closed** (D71) : la ligne sans propriétaire est invisible ;
+  le non-exposé est le défaut ;
+- **La librairie inviolable** (D599) : « la librairie mise en place
+  assure l'inviolabilité des règles et des droits » — le hook est un
+  citoyen du moteur, jamais un super-utilisateur.
+
+## La confidentialité (D25–D27, D364)
+
+Le niveau d'exposition d'une donnée : **`public`** (partout),
+**`protected`** (l'interface et les tâches), **`private`** (les
+tâches seulement) — **resserrable par groupes**, déclarable à
+l'entité et **au champ** (D364) :
+
+```yaml
+fields:
+  salary:
+    type: amount
+    confidentiality: protected      # le niveau (D25), resserrable (D26)
+```
+
+La confidentialité irrigue tout : les menus filtrés (D193), l'export
+aux colonnes visibles (D196), les widgets hérités surchargeables
+(Q53), la communication (D393).
+
+## Les droits d'action (D196, D421–D427)
+
+**Les droits d'action par entité s'inscrivent au modèle de
+confidentialité** (D196). Deux foyers exclusifs — le nom unique
+`allow` (D422–D423, « les 2 simultanément ne seront pas autorisés »,
+l'erreur d'ingestion) :
+
+```yaml
+# LE CYCLE : allow par état (D422) — chaque état porte ses droits
+fields:
+  status:
+    type: enum
+    values:
+      draft:    { allow: [create, read, update, delete] }
+      archived: { allow: [read, delete] }
+
+# OU LA FORME LIBRE : le bloc allow d'en-tête, verbe → expression (D90)
+name: order
+allow:
+  update: locked = false
+  delete: false
+```
+
+L'absence = tout permis ; **les opérations passent outre** (D422 —
+l'acte déclaré porte sa propre légitimité) ; `read` absent = l'état
+masque.
+
+## L'audience et l'anti-IDOR (D70–D77, D144, D153)
+
+- **Les deux audiences** (D70) : l'interne (les collaborateurs — les
+  groupes et les niveaux) et l'externe (les clients — l'accès au
+  niveau ligne, fermé par défaut) ;
+- **l'appartenance** (D71) : directe (le champ référence-compte),
+  indirecte (le chemin multi-saut `commande.client.compte`), ouverte
+  (les catalogues), ou non exposée (le défaut) ; les chemins
+  multiples s'unissent, la ligne sans propriétaire est invisible ;
+- **les identifiants opaques** (D75/D82) : l'UUID interne jamais
+  exposé — l'anti-IDOR ; la pagination au curseur opaque (D100) ;
+- **la typologie des comptes** (D77) : technique (l'API),
+  utilisateur interne, client provisionné, client auto-créé
+  (vérifié) — l'étanchéité par canal.
+
+## Les groupes et les modules (D341, D414–D416)
+
+- **`groups.yml`** à la racine de la version — la hiérarchie sans
+  lien parent (« un groupe est constitué d'autres groupes »),
+  acyclique, la multi-appartenance naturelle (D414) ;
+- **les affectations vivent en base** — l'acte d'administration
+  (D341), jamais dans le dépôt ;
+- **le module restreint** (D190/D416) : l'affectation
+  utilisateur↔module ouvre une surface — elle n'étend jamais un
+  droit.
+
+## Les connecteurs et la sécurité (D603, D626, D633, D642)
+
+- **les secrets** : la référence à une variable d'environnement,
+  chiffrable par une clé environnement+machine (D603) — le dépôt ne
+  porte jamais une valeur en clair ;
+- **la condition indispensable** (D626) : l'application ne démarre
+  que si le mail à l'administrateur est possible — le canal d'alerte
+  avant tout ;
+- **le `directory` en lecture seule** (D633) — la synchronisation
+  des comptes, jamais l'écriture vers l'annuaire ;
+- **le webhook à l'authentification obligatoire** (D642) — aucune
+  entrée anonyme, la garde d'office sur la route.
+
+## La provenance et la trace (D62, D178, D238, D429)
+
+Toute écriture est tracée (D62) ; la provenance de la reprise
+persiste après la mort du connecteur (D178) ; l'import
+d'exploitation porte l'opérateur (D238) ; la trace des opérations
+est l'historisation elle-même (D429).
+
+## Les points ouverts — le chantier du sujet 2
+
+1. **L'authentification** — les trois flags accumulés : la
+   passerelle (D418 — le lien utilisateur↔annuaire), les modes (le
+   compte local, l'AD via `directory`, le SSO ?), la session (la
+   durée, le renouvellement), les API (le jeton — le compte
+   technique D77), le mécanisme concret de la garde webhook (D642 —
+   la clé, le jeton, la signature ?) ;
+2. **le droit de déclencher** — D196 couvre les actions d'entité ;
+   le droit d'exécuter une opération déclarée (les 18 du socle, les
+   hooks) est-il entièrement couvert, ou manque-t-il un grain ?
+3. **le RGPD** — les données personnelles marquées au modèle ? le
+   droit à l'effacement face à l'historisation (D168) et à la
+   provenance persistante (D178) ; la rétention ;
+4. **l'audit** — la trace des écritures existe ; l'audit des
+   **lectures** (qui a consulté quoi), celui des actes
+   d'administration, la surface qui le consulte ;
+5. **le chiffrement** — au repos (le storage), en transit.

--- a/docs/rights.md
+++ b/docs/rights.md
@@ -223,27 +223,60 @@ degré** (`degree:` dans groups.yml — en proposition, défaut
 sans groupe n'entre pas (le fail-closed jusqu'à la porte). Et
 **`allow:` complète en précisant les groupes autorisés** (D700) :
 
+**L'inventaire des dix-neuf planchers** (D701 — validé) :
+
+| le degré | les opérations |
+|---|---|
+| `user` | `create` · `read` · `update` · `delete` · `duplicate` · `promote` · `demote` · `generate` · `download` · `print` · `send` · `export` · `notify` · `refresh` |
+| `manager` | `import` · `report` |
+| `administrator` | `restore` · `migrate` · `anonymize` |
+
+**L'exemple détaillé** — les degrés, les deux formes d'`allow` et la
+composition :
+
 ```yaml
 # groups.yml — le degré porté par le groupe (D699)
 groups:
-  sales_team: { }                      # degree: user (le défaut)
-  managers:   { degree: manager, groups: [sales_team] }
+  sales_team: { }                          # degree: user (le défaut)
+  accounting: { }
+  managers:   { degree: manager, groups: [sales_team, accounting] }
   admins:     { degree: administrator }
 
-# l'entité — allow: l'expression OU les groupes (D423/D700)
-allow:
-  update: locked = false
-  delete: [admins]
+# sales/entities/order.yml — LE CYCLE : allow par état (D422)
+name: order
+fields:
+  status:
+    type: enum
+    values:
+      draft:     { allow: [create, read, update, delete] }
+      confirmed: { allow: [read] }
+      archived:  { allow: [read] }
 operations:
   archive:
-    allow: [managers, admins]          # le droit de déclencher (D691)
+    allow: [managers, admins]              # le droit de déclencher (D691/D700)
+    commit: confirm
+  purge_customer:
+    operations: [ anonymize ]              # la 19e (D697) — plancher administrator
+    # un allow: [managers] serait sans effet : le plancher l'emporte (D700)
+
+# sales/entities/customer.yml — LA FORME LIBRE (D423), exclusive du cycle
+name: customer
+allow:
+  update: locked = false                   # l'expression (D90)
+  delete: [admins]                         # les groupes (D700)
 ```
 
-Le plancher et l'`allow:` se composent — **le plus exigeant
-l'emporte**. *(L'inventaire des dix-neuf planchers — en
-proposition : `user` pour le quotidien, `manager` pour
-`import`/`report`, `administrator` pour
-`restore`/`migrate`/`anonymize` — reste à valider.)*
+**Qui peut quoi** — la composition (le plus exigeant l'emporte) :
+
+| l'acteur (son meilleur groupe) | `archive` une commande | `purge_customer` | `delete` un client |
+|---|---|---|---|
+| un membre de `sales_team` (user) | non — hors de l'`allow` | non — le plancher `administrator` | non — l'`allow` exige `admins` |
+| un membre de `managers` (manager) | **oui** — dans l'`allow`, le plancher `user` de l'opération déclarée est couvert | non — le plancher `administrator` l'emporte sur tout `allow` | non — l'`allow` exige `admins` |
+| un membre de `admins` (administrator) | **oui** | **oui** — le plancher atteint | **oui** — et l'expression `update: locked = false` continue de gouverner la modification |
+
+— et dans tous les cas, un compte **sans groupe n'entre pas** (D699,
+le fail-closed jusqu'à la porte) ; la vérification joue **au début**
+de l'opération, servie par le cache de droits (D694).
 
 ## Les points ouverts — le chantier du sujet 2
 

--- a/docs/rights.md
+++ b/docs/rights.md
@@ -212,10 +212,41 @@ fields:
   D333/D645) : les champs `rgpd:`, leur confidentialité, leur
   rétention, leurs connecteurs sortants — généré, jamais rédigé.
 
+## Le degré intrinsèque d'autorisation (D697, D699–D700)
+
+**Le contrat de chaque opération déclare son degré** — le plancher
+que la déclaration ne peut abaisser. **Les trois valeurs** : `user`
+· `manager` · `administrator`. **Le groupe d'utilisateurs porte le
+degré** (`degree:` dans groups.yml — en proposition, défaut
+`user`) ; l'utilisateur atteint le degré de son meilleur groupe
+(D414) ; **l'appartenance à un groupe est obligatoire** — le compte
+sans groupe n'entre pas (le fail-closed jusqu'à la porte). Et
+**`allow:` complète en précisant les groupes autorisés** (D700) :
+
+```yaml
+# groups.yml — le degré porté par le groupe (D699)
+groups:
+  sales_team: { }                      # degree: user (le défaut)
+  managers:   { degree: manager, groups: [sales_team] }
+  admins:     { degree: administrator }
+
+# l'entité — allow: l'expression OU les groupes (D423/D700)
+allow:
+  update: locked = false
+  delete: [admins]
+operations:
+  archive:
+    allow: [managers, admins]          # le droit de déclencher (D691)
+```
+
+Le plancher et l'`allow:` se composent — **le plus exigeant
+l'emporte**. *(L'inventaire des dix-neuf planchers — en
+proposition : `user` pour le quotidien, `manager` pour
+`import`/`report`, `administrator` pour
+`restore`/`migrate`/`anonymize` — reste à valider.)*
+
 ## Les points ouverts — le chantier du sujet 2
 
-1. **le degré intrinsèque d'autorisation** (D697) — l'inventaire
-   des planchers des dix-neuf opérations du socle ;
 2. **l'audit** — la trace des écritures existe ; l'audit des
    **lectures** (qui a consulté quoi), celui des actes
    d'administration, la surface qui le consulte ;

--- a/docs/types.md
+++ b/docs/types.md
@@ -23,8 +23,9 @@ composants.md.
   similarity[0.8] / range / mutualizable[nom] — selon le type),
   `mask`, `report:` (`no` par défaut — D406), la confidentialité
   (D25/D364), **`rgpd:`** (`personal` / `sensitive` / `consent` —
-  D695, l'anonymisation D696), `component`/`style`/`size` (la
-  cascade D461 — le plus proche l'emporte) ;
+  D695, l'anonymisation D696), **`trace:`** (`audit` / `limited` —
+  D703 ; le sensitive audité d'office), `component`/`style`/`size`
+  (la cascade D461 — le plus proche l'emporte) ;
 - **le tri et le nul** (D368 et suivantes) — chaque type porte sa
   règle ; **le nul des composés se trie en premier** (D391) ;
 - **la signature du type** (D579–D584) : **la conversion

--- a/docs/types.md
+++ b/docs/types.md
@@ -22,8 +22,9 @@ composants.md.
   valeur intercalée), `searchable` (strict / normalized /
   similarity[0.8] / range / mutualizable[nom] — selon le type),
   `mask`, `report:` (`no` par défaut — D406), la confidentialité
-  (D25/D364), `component`/`style`/`size` (la cascade D461 — le plus
-  proche l'emporte) ;
+  (D25/D364), **`rgpd:`** (`personal` / `sensitive` / `consent` —
+  D695, l'anonymisation D696), `component`/`style`/`size` (la
+  cascade D461 — le plus proche l'emporte) ;
 - **le tri et le nul** (D368 et suivantes) — chaque type porte sa
   règle ; **le nul des composés se trie en premier** (D391) ;
 - **la signature du type** (D579–D584) : **la conversion


### PR DESCRIPTION
## La sécurité et les droits — le sujet 2 de la passe de complétude soldé (D690–D708)

**Le sujet 2 est soldé** : 19 décisions, un nouvel artefact documentaire (`rights.md` — le huitième), et le §1.2 tenu à jour.

### rights.md créé (D690)

Le huitième artefact, à la méthode des connecteurs : la doctrine (la sécurité par construction P8, restreindre jamais étendre, masquer jamais détruire, l'anti-oracle, le fail-closed, la librairie inviolable), l'acquis consolidé avec les exemples du registre (la confidentialité D25/D364, les deux foyers `allow` D422–D423, l'audience anti-IDOR D70–D77, les groupes et modules, les connecteurs, la provenance).

### L'authentification (D692–D694)

- **La famille `authentication`** (D692) — la huitième famille de connecteur : le contrat **`challenge()`/`verify(preuve)`** aux deux visages (l'utilisateur → la session ; l'API → la preuve au porteur, le 401 en défi) ; **les quatre volets** : `local`, `azure_ad`, `sso`, l'API ; **la garde du webhook (D642) appelle le même `verify`** — le flag refermé, la passerelle (D418) incarnée.
- **La session** (D693) : `duration` (l'inactivité au glissement, 8h) et `limit` (l'absolu, 7d) en settings dynamiques ; les sessions simultanées libres, la révocation administrateur ; la session ne fige jamais des droits.
- **La vérification au début, le cache de droits** (D694) : l'acte entamé s'achève sous les droits de son départ ; le cache invalidé aux modifications administratives.

### Les droits et le degré intrinsèque (D691, D699–D701)

- **Les droits d'action couvrent les opérations** du socle et les déclarées (D691) — la réconciliation avec le passe-outre de D422 consignée : on contrôle qui appuie, pas ce que l'acte écrit.
- **Le degré intrinsèque au contrat des opérations** (D699) : `user` / `manager` / `administrator` — **le groupe porte le degré** (`degree:`), **l'appartenance à un groupe est obligatoire** ; `allow:` précise les groupes autorisés (D700) — le plus exigeant l'emporte ; **l'inventaire des 19 planchers validé** (D701), l'exemple détaillé « qui peut quoi » dans rights.md.

### Le RGPD (D695–D698)

Le marquage **`rgpd: personal | sensitive | consent`** (l'article 9) ; **l'anonymisation par algorithme** à règle aléatoire, jamais dérivée de l'origine — les enregistrements et les historiques ; **`anonymize`, la dix-neuvième opération du socle** (l'administration) ; la rétention échue qui anonymise d'office, le registre des traitements auto-documenté.

### L'audit des lectures (D702–D704)

Le grain à l'acte (la lecture en masse ou la transaction, le nombre d'éléments — jamais l'enregistrement) ; le `rgpd: sensitive` audité d'office ; **`trace: audit`** (l'opt-in) et **`trace: limited`** (l'exclusion — le mot de passe, la clé, nulle part tracés) ; l'entité d'audit au module d'administration.

### Le chiffrement (D705–D708)

Le transit : servi = HTTPS sans dérogation, appelé = chiffré par défaut à l'exception déclarée ; le repos : le storage hors responsabilité, **le chiffrement est un pouvoir de type** (comme `password` — les fonctions de valeur du visiteur) ; **les clés obligatoirement chiffrées** (le `.env` jamais versionné) et **les commandes `encrypt`/`decrypt`** de Syncytium.

### Les documents

`rights.md` créé et nourri à chaque décision ; `hooks.md` (19 opérations, le degré au contrat, la famille authentication), `connectors.md` (les huit familles, le contrat authentication), `types.md` (`rgpd:`, `trace:` au kit), `glossaire.md` (le groupe au degré) tenus au niveau.

### Ce qui reste

Le sujet 3 — l'administration et l'exploitation : le module d'administration (les sessions, l'audit, la vue de migration, la rotation des clés), la télémétrie (Q12–Q13) — avant les cas d'usage (Q59) et la documentation (Q58).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
