### PR TITLE
L'administration et l'exploitation — le sujet 3 en grande partie soldé (D709–D733)

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -28,6 +28,25 @@ de complétude).
   alertes et les rapports naissent du modèle — rien ne s'ajoute
   après coup.
 
+## Le module d'administration (D710)
+
+**Un seul module, au degré minimal `administrator`** — le premier
+module à plancher : l'affectation ne suffit pas, le degré du groupe
+(D699) est exigé — la double garde. **Les entrées sont un menu
+construit et maintenu dans Syncytium** :
+
+- les settings (la surcharge des dynamiques — D588) ;
+- la gestion des comptes (D77/D82/D341) ;
+- les sessions (D693) ;
+- l'audit (D704) ;
+- … (la liste reste ouverte — elle s'enrichit avec le socle).
+
+**Le module exploite les différentes facettes de Syncytium** — le
+module (D416), les entités, les menus (D193/D440), les composants
+graphiques (D437–D569) : l'administration n'a rien de spécial, elle
+est une application Syncytium (le patron D666 généralisé). *(Le
+module `migration` — D666 — demeure distinct.)*
+
 ## Les actes d'administration consignés
 
 ### Les comptes et les affectations
@@ -144,17 +163,13 @@ restent à clore** — le sujet 3 les portera.
 
 ## Les points ouverts — le chantier du sujet 3
 
-1. **la nature et le périmètre du module d'administration** — un
-   module porté par Syncytium : l'inventaire de ses entités et de
-   ses surfaces, sa place dans les menus, son rapport au module
-   `migration` (D666) ;
-2. **les comptes au quotidien** — la création du compte local, le
+1. **les comptes au quotidien** — la création du compte local, le
    cycle de vie (l'invitation ? le mot de passe oublié ? le
    verrouillage ?), la re-liaison D82 en pratique ;
-3. **l'exploitation courante** — la sauvegarde (au-delà de la
+2. **l'exploitation courante** — la sauvegarde (au-delà de la
    restauration D174), **la rotation des clés** (le flag D707),
    l'automatisation d'`encrypt` (le flag D708), la santé de
    l'instance en une vue ;
-4. **la télémétrie** (Q12–Q13) — ce qu'elle collecte, où elle vit
+3. **la télémétrie** (Q12–Q13) — ce qu'elle collecte, où elle vit
    (des entités du module d'administration ?), qui la voit, le lien
    au volet conseil (P9).

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -71,6 +71,23 @@ est une application Syncytium (le patron D666 généralisé).
 Les familles `authentication` (D692) et `directory` (D633)
 **coopèrent** — comme `file` et `storage` (D636) : l'une authentifie,
 l'autre fournit la lecture des groupes et des utilisateurs.
+**Keycloak** entre comme une classe de la famille `authentication`
+(D716 — le visage concret du volet SSO) ; **le groupe
+`administrator` peut être associé à un groupe du directory** (D717 —
+la double entrée demeure : la désignation individuelle reste l'acte
+local).
+
+### Le mode safe (D718)
+
+**La porte de secours** — quand l'annuaire est injoignable, le SSO
+cassé ou les droits verrouillés par erreur : **un mode d'exécution
+au lancement** de l'application (jamais atteignable depuis
+l'application vivante) — **le module administration seul** (aucune
+donnée métier servie), l'accès par **le compte administrateur
+principal** et **le mot de passe fixé à l'installation** (le patron
+des secrets D707 — hors annuaire, hors configuration versionnée) ;
+le mode safe est **tracé** (l'audit D704) — la porte de secours
+n'est jamais une porte dérobée.
 
 ### Les opérations dédiées et la délégation (D714–D715)
 

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -35,17 +35,21 @@ module à plancher : l'affectation ne suffit pas, le degré du groupe
 (D699) est exigé — la double garde. **Les entrées sont un menu
 construit et maintenu dans Syncytium** :
 
-- les settings (la surcharge des dynamiques — D588) ;
-- la gestion des comptes (D77/D82/D341) ;
-- les sessions (D693) ;
-- l'audit (D704) ;
+- **les settings** — les paramètres **statiques et dynamiques**
+  (D588/D711) : la consultation des deux, la surcharge des seuls
+  dynamiques (le statique se change par une version) ;
+- **la gestion des comptes** (D77/D82/D341) ;
+- **les sessions** (D693) ;
+- **l'audit** (D704) ;
+- **les migrations** (D666/D711) — **l'entrée conditionnelle** :
+  disponible seulement si `migrations:` est défini dans la
+  configuration (D662) ;
 - … (la liste reste ouverte — elle s'enrichit avec le socle).
 
 **Le module exploite les différentes facettes de Syncytium** — le
 module (D416), les entités, les menus (D193/D440), les composants
 graphiques (D437–D569) : l'administration n'a rien de spécial, elle
-est une application Syncytium (le patron D666 généralisé). *(Le
-module `migration` — D666 — demeure distinct.)*
+est une application Syncytium (le patron D666 généralisé).
 
 ## Les actes d'administration consignés
 
@@ -88,12 +92,13 @@ le défaut automatique (`rgpd: sensitive`), `trace: audit`/`limited` ;
 les surfaces standard la consultent (le degré `administrator`), la
 rétention déclarée (D411).
 
-### Le suivi des migrations (D666–D668)
+### Le suivi des migrations (D666–D668, D711)
 
-Le module `migration` (porté par Syncytium) : les entités du suivi —
-la couverture par migration/entité/règle, les rejets et leurs
-causes — **historisées** (l'évolution de la qualité dans le temps) ;
-la vue par les surfaces standard.
+**L'entrée « migrations » du module d'administration** (D711 —
+conditionnelle : `migrations:` défini) : les entités du suivi — la
+couverture par migration/entité/règle, les rejets et leurs causes —
+**historisées** (l'évolution de la qualité dans le temps) ; la vue
+par les surfaces standard.
 
 ### Les opérations d'administration du socle (D701)
 

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -158,6 +158,12 @@ settings:
   survivant désigné, l'autre **désactivé** (jamais supprimé) ; **la
   perte éventuelle des historiques du compte désactivé est
   assumée** — pas de re-parentage rétroactif des traces.
+- **les mails du socle** (D723) : l'invitation, la réinitialisation
+  et la validation de changement d'adresse sont **des templates
+  `mail` du socle** (D562/D564 — le mustache + markdown, l'envoi par
+  le smtp D628, la langue de l'utilisateur D217–D225) ; **Syncytium
+  les fournit par défaut, la configuration de l'application peut les
+  redéfinir** (D186).
 
 ### Les opérations dédiées et la délégation (D714–D715)
 

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -1,0 +1,160 @@
+# L'administration et l'exploitation de Syncytium
+
+Ce document rassemble **les actes d'administration et les éléments
+d'exploitation consignés** — le neuvième artefact préparatoire de la
+documentation (Q58, le domaine 6 — D602), après le
+[glossaire](glossaire.md), les [composants](composants.md), les
+[hooks](hooks.md), les [types](types.md), les
+[connecteurs](connectors.md), le [mapping](mapping.md) et les
+[droits](rights.md). Les décisions citées renvoient à la
+[conception](conception.md). Il consolide l'acquis épars et porte
+les points du chantier ouvert (le sujet 3 — le dernier de la passe
+de complétude).
+
+## La doctrine
+
+- **Les actes d'administration vivent en base, jamais dans le
+  dépôt** (D341) : la configuration décrit les possibles (les
+  groupes, les modules, les settings), l'administration affecte et
+  ajuste — les deux mondes ne se mélangent pas ;
+- **le degré `administrator`** (D699/D701) garde les gestes : porté
+  par le groupe, l'appartenance obligatoire — le plancher que la
+  déclaration ne peut abaisser ;
+- **le module porté par Syncytium** (le patron D666) : le socle est
+  le premier client du mécanisme (D408) — les entités et les
+  surfaces d'administration sont des entités et des surfaces
+  standard ;
+- **expliciter plutôt que subir en silence** : la supervision, les
+  alertes et les rapports naissent du modèle — rien ne s'ajoute
+  après coup.
+
+## Les actes d'administration consignés
+
+### Les comptes et les affectations
+
+- **la typologie des comptes** (D77) : technique (l'API),
+  utilisateur interne, client provisionné par l'ADV, client
+  auto-créé vérifié — l'étanchéité par canal ;
+- **l'identité interne = l'UUID stable** (D82) ; la clé d'unicité
+  définie par le connecteur (le GUID Entra + courriel, le login
+  local) — **l'opération d'administration de re-liaison/fusion**
+  des comptes ;
+- **les affectations** utilisateur↔groupes et utilisateur↔modules
+  (D341/D414–D416) — en base, par l'administrateur ; le groupe porte
+  le degré (D699), **l'appartenance à un groupe est obligatoire** ;
+- **le provisionnement** : les utilisateurs associés par le
+  technicien ou par la passerelle d'authentification (D418/D692 —
+  la famille `authentication`, la synchronisation par le
+  `directory` D633) ;
+- **les jetons des comptes techniques** (D692) : créés et révoqués
+  par l'administration — la classe `local` les vérifie.
+
+### Les sessions (D693)
+
+Les sessions d'un compte **visibles et coupables** — la révocation
+est un acte d'administration ; les réglages (`duration`/`limit`) en
+settings dynamiques, ajustables sans republier.
+
+### Les settings dynamiques (D588–D590)
+
+`{ mode: dynamic, type:, value: }` — la valeur par défaut déclarée,
+**surchargée via le module d'administration** ; la cascade
+application → module → entité.
+
+### L'audit (D702–D704)
+
+L'entité d'audit **vit au module d'administration** : le grain à
+l'acte (la lecture en masse, la transaction, le nombre d'éléments),
+le défaut automatique (`rgpd: sensitive`), `trace: audit`/`limited` ;
+les surfaces standard la consultent (le degré `administrator`), la
+rétention déclarée (D411).
+
+### Le suivi des migrations (D666–D668)
+
+Le module `migration` (porté par Syncytium) : les entités du suivi —
+la couverture par migration/entité/règle, les rejets et leurs
+causes — **historisées** (l'évolution de la qualité dans le temps) ;
+la vue par les surfaces standard.
+
+### Les opérations d'administration du socle (D701)
+
+Les planchers `administrator` : **`restore`** (la restauration par
+renommage — le geste inverse de la bascule, D174/D678),
+**`migrate`** (D667), **`anonymize`** (D697) ; les planchers
+`manager` : **`import`** (D211/D238), **`report`**.
+
+## L'exploitation consignée
+
+### Les environnements (D339, D342–D343)
+
+`environments/` — un dossier par environnement (staging, production
+active, passive) : `environment.yml` + les connecteurs (D617) + les
+journaux + les settings + la documentation, **spécifiques à
+chacun** ; l'actif/passif du PCA-PRA (D112–D114) — la réplication
+différentielle (le mode `relative` de la migration, D649/D671).
+
+### Les journaux (D343)
+
+Par environnement : le staging en **debug/verbose**, la production
+active en **info + puits de logs éventuel**, la passive en
+**warning** — les formats et les emplacements différents ; les
+journaux en anglais (D217–D225).
+
+### La supervision (D621, D625–D627)
+
+- **`ping()`** sur chaque connecteur — les statuts (`error`,
+  `initialized`, `disconnected`, `connected`, `closed`…), la
+  fréquence à l'`every:` ;
+- **la position de sécurité** : l'erreur → la page de maintenance +
+  **l'alerte émise** ; l'`onerror` gradué (le mock du connecteur non
+  critique, la maintenance du connecteur clé) ;
+- **la condition indispensable** (D626) : l'application ne démarre
+  que si le mail à l'administrateur est possible — le canal d'alerte
+  avant tout.
+
+### Les secrets (D603, D707–D708)
+
+Le `.env` jamais versionné, les clés obligatoirement chiffrées (la
+clé dérivée environnement + machine) ; **les commandes** :
+
+```bash
+syncytium encrypt DB_PASSWORD "le-mot-de-passe"   # chiffre et enregistre
+syncytium decrypt DB_PASSWORD                      # la vérification, le débogage
+```
+
+### Le cycle de vie des versions (D338–D340, D332)
+
+Le statut = l'emplacement (`beta/`, `production/`, `deprecated/`,
+`forbidden/`) — les transitions par gestes de fichier ; le registre
+des versions essayées (le retry par bump du build) ; le délai de
+grâce du schéma remplacé (D675/D678).
+
+## La télémétrie — le chantier (P9, Q12–Q13 ouvertes)
+
+L'acquis du pilier P9 (D38–D51, D97) : **les trois finalités** — les
+usages (la diversité des valeurs par champ D38, les compteurs
+d'entité D39), le risque de migration, la sécurité (les seuils
+déclarés aux endpoints/entités/fonctions d'IHM — D50 ; la
+calibration ajustable à l'initialisation — D97 : fenêtre 30 jours,
+z-score ≥ 3, planchers) ; la détection des séquences répétées
+(SEQUITUR — D315–D319 : les optimisations et **les services
+proposés** au technicien, avec fréquence et gain) ; la restitution
+en tableaux de bord et synthèses, le volet conseil. **Q12–Q13
+restent à clore** — le sujet 3 les portera.
+
+## Les points ouverts — le chantier du sujet 3
+
+1. **la nature et le périmètre du module d'administration** — un
+   module porté par Syncytium : l'inventaire de ses entités et de
+   ses surfaces, sa place dans les menus, son rapport au module
+   `migration` (D666) ;
+2. **les comptes au quotidien** — la création du compte local, le
+   cycle de vie (l'invitation ? le mot de passe oublié ? le
+   verrouillage ?), la re-liaison D82 en pratique ;
+3. **l'exploitation courante** — la sauvegarde (au-delà de la
+   restauration D174), **la rotation des clés** (le flag D707),
+   l'automatisation d'`encrypt` (le flag D708), la santé de
+   l'instance en une vue ;
+4. **la télémétrie** (Q12–Q13) — ce qu'elle collecte, où elle vit
+   (des entités du module d'administration ?), qui la voit, le lien
+   au volet conseil (P9).

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -242,6 +242,24 @@ journaux + les settings + la documentation, **spécifiques à
 chacun** ; l'actif/passif du PCA-PRA (D112–D114) — la réplication
 différentielle (le mode `relative` de la migration, D649/D671).
 
+### Le lien actif/passif (D724)
+
+**Le passif est dormant** — ni lecture ni service pendant la vie
+normale. **Les trois modes de gestion** (l'écriture `replication:`
+en proposition, dans `environments/passive.yml`) :
+
+| le mode | la mécanique | le failback |
+|---|---|---|
+| `brut` | **la copie de l'instance à intervalle régulier** — les fichiers des entités, les fichiers de configuration et la base | non |
+| `differentiel` | **la base au natif du moteur ou de l'infrastructure** (Syncytium ne gère pas la base) ; Syncytium synchronise **les fichiers des entités et de configuration** | non |
+| `synchronous` | **les actions historisées, transmises au passif, l'exécution confirmée supprime l'action en attente** (le patron de la file — D686) | **oui** — les actions du passif pendant l'incident reprennent le même chemin |
+
+**Une montée de version est couverte par les trois modes** : la
+copie l'emporte (brut), les fichiers de configuration la portent
+(differentiel), l'action de migration s'expédie comme les autres
+(synchronous). La bascule reste un acte d'exploitation ; le retard
+de synchronisation se surveille (l'alerte D626 au-delà d'un seuil).
+
 ### Les journaux (D343)
 
 Par environnement : le staging en **debug/verbose**, la production

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -329,6 +329,14 @@ réel** (D732) : pas de période de rafraîchissement — l'état pousse
 (`refresh: live` — D249/D555) ; l'`every:` du `ping()` rythme la
 mesure, jamais l'affichage.
 
+**Le mail des faits marquants** (D733) : le technicien reçoit, **une
+fois par jour ou à sa convenance** (l'`every:` calendaire D434), le
+résumé de la période — **les utilisateurs connectés, les
+erreurs/warnings (D343), les changements d'état de santé** (la
+liste ouverte) — fondé sur le statut de santé et **son évolution au
+cours de la journée** ; le template mail du socle (D723),
+surchargeable en configuration, l'envoi par le smtp (D628).
+
 ### Les journaux (D343)
 
 Par environnement : le staging en **debug/verbose**, la production

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -89,6 +89,43 @@ des secrets D707 — hors annuaire, hors configuration versionnée) ;
 le mode safe est **tracé** (l'audit D704) — la porte de secours
 n'est jamais une porte dérobée.
 
+### Le détail de l'utilisateur et du groupe (D719)
+
+```yaml
+# l'entité système user — définie, construite et maintenue par
+# Syncytium, jamais déclarée par le technicien
+user:
+  label: "{first_name} {last_name}"
+  fields:
+    login:        { type: text, rgpd: personal }      # la clé d'unicité (D82)
+    email:        { type: email, rgpd: personal }
+    first_name:   { type: text, rgpd: personal }
+    last_name:    { type: text, rgpd: personal }
+    language:     reference                            # la langue → le fuseau (D217–D225)
+    account_type: enum [technical, internal, customer] # la typologie (D77)
+    origin:       reference                            # le connecteur d'authentification (D713)
+    status:       enum [active, banned, locked]        # ban (D714), le verrouillage
+    admin:        boolean                              # la désignation individuelle (D712)
+    password:     password                             # le local seul — jamais relu (D463)
+    groups:       association with group               # l'affectation en base (D341)
+    modules:      association with module              # l'affectation en base (D416)
+
+# groups.yml — la configuration (le déclaré)
+groups:
+  managers:
+    degree: manager                    # D699
+    groups: [sales_team, accounting]   # la composition acyclique (D414)
+    directory: ["GRP-AD-Managers"]     # l'association aux groupes AD (D713/D717)
+```
+
+**Les régimes** : la fiche synchronisée en **lecture seule** (D713 —
+sauf `admin`, `modules`, `status` : les propriétés hors annuaire) ;
+l'UUID interne hors déclaration (D142) ; l'entité **historisée**
+(qui a donné quel droit, quand), ses lectures à l'audit. **La ligne
+de partage** : la configuration déclare la structure (les groupes,
+les degrés, `directory:`), la base porte les appartenances —
+l'écran du groupe montre les deux faces.
+
 ### Les opérations dédiées et la délégation (D714–D715)
 
 - les surfaces : **les utilisateurs** et **les groupes** en listes

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -261,6 +261,71 @@ copie l'emporte (brut), les fichiers de configuration la portent
 (synchronous). La bascule reste un acte d'exploitation ; le retard
 de synchronisation se surveille (l'alerte D626 au-delà d'un seuil).
 
+**La déclaration** (D726) — dans `environments/passive.yml` :
+
+```yaml
+replication: disabled                  # le défaut (D725) — pas de passif
+
+replication:
+  mode: brut                           # la copie entière (D724)
+  every: daily[02:00]
+
+replication:
+  mode: differential                   # la base au natif ; les fichiers par Syncytium
+  every: 15min
+
+replication:
+  mode: synchronous                    # le journal d'actions — le flux continu
+```
+
+### La sauvegarde et la restauration (D727–D729)
+
+- **la sauvegarde** (D727) : `duplicate_instance` (D680) + les
+  fichiers des entités + la configuration, **vers une destination
+  précisée** — un zip ou un espace de stockage ; **la rétention en
+  jours** (l'archive échue supprimée) :
+
+```yaml
+backup:
+  destination: zip:/backups/           # ou un connecteur de stockage
+  every: daily[01:00]
+  retention: 30d
+```
+
+- **la restauration** (D728) : **une image à sa propre vie** —
+  l'adresse du point d'entrée fournie au geste, l'application
+  restaurée devient une application comme les autres (le clonage
+  assumé : le staging depuis la production, l'archive consultable) ;
+- **les bibliothèques d'applications** (D729) : la sauvegarde en
+  **gabarit distribuable** (le « Hello world ! » D337 industrialisé,
+  l'écosystème AGPL) — à la restauration, **le wizard
+  d'initialisation** demande les paramètres clés (le storage, les
+  connecteurs — l'assistant des secrets D707/D708 enchaîné), **ou le
+  storage sqlite natif** épargne toute question : l'application
+  démarre seule.
+
+### La rotation des clés (D730)
+
+Deux déclencheurs : **chaque restauration** (l'image nouvelle, la
+machine peut-être autre — la clé environnement + machine D603 impose
+la naturalisation) et **la commande** :
+
+```bash
+syncytium rotate    # re-chiffre le .env et les champs des types chiffrants
+```
+
+— le re-chiffrement en masse au patron de `migrate` (la transaction,
+la progression suivie), l'acte tracé.
+
+### La santé (D731)
+
+La vue d'office du module d'administration : **les statuts, les
+files d'attente (D686), les sessions actives, les connecteurs** (le
+`ping()` D621 — le feu tricolore) — disponible **en dashboard et en
+API** (la supervision externe interroge l'API) ; **l'état de santé
+du passif intégré** quand la réplication est active (le retard, le
+dernier passage, l'alerte au seuil — D626).
+
 ### Les journaux (D343)
 
 Par environnement : le staging en **debug/verbose**, la production
@@ -312,10 +377,6 @@ restent à clore** — le sujet 3 les portera.
 
 ## Les points ouverts — le chantier du sujet 3
 
-1. **l'exploitation courante** — la sauvegarde (au-delà de la
-   restauration D174), **la rotation des clés** (le flag D707),
-   l'automatisation d'`encrypt` (le flag D708), la santé de
-   l'instance en une vue ;
-2. **la télémétrie** (Q12–Q13) — ce qu'elle collecte, où elle vit
+1. **la télémétrie** (Q12–Q13) — ce qu'elle collecte, où elle vit
    (des entités du module d'administration ?), qui la voit, le lien
    au volet conseil (P9).

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -53,6 +53,38 @@ est une application Syncytium (le patron D666 généralisé).
 
 ## Les actes d'administration consignés
 
+### L'organisation des comptes (D712–D713)
+
+- **le groupe `administrator` par défaut** (D712) : le socle le
+  fournit d'office (groups.yml n'a pas à le déclarer) ; **l'accès
+  administrateur est à double entrée** — l'appartenance au groupe
+  **et** la désignation individuelle de l'utilisateur (l'affectation
+  nominative D341) ;
+- **la synchronisation selon le mode d'authentification** (D713) :
+
+| le mode | la source des comptes | l'édition dans Syncytium |
+|---|---|---|
+| `local` | la création et l'affectation **manuelles** par l'administrateur | pleine |
+| `azure_ad` | **le groupe Syncytium associé à un ou plusieurs groupes AD** — la classe d'authentification récupère les groupes puis leurs utilisateurs (le contrat `directory` D633 : `get_groups`, `get_users_from_group`) | **lecture seule** (l'annuaire est maître) — sauf les propriétés hors annuaire |
+| `sso` | comme le directory | lecture seule — **sans la gestion du mot de passe** |
+
+Les familles `authentication` (D692) et `directory` (D633)
+**coopèrent** — comme `file` et `storage` (D636) : l'une authentifie,
+l'autre fournit la lecture des groupes et des utilisateurs.
+
+### Les opérations dédiées et la délégation (D714–D715)
+
+- les surfaces : **les utilisateurs** et **les groupes** en listes
+  standard ;
+- **`renew`** — le changement (ou le changement forcé) du mot de
+  passe : le lien de réinitialisation, jamais la valeur ;
+- **`ban`** — le bannissement **sans suppression** (masquer, jamais
+  détruire) ; la liste des opérations reste ouverte ;
+- **la délégation** (D715) : agir **à la place** d'un utilisateur —
+  les droits joués sont ceux de l'emprunté, et **chaque trace porte
+  les deux comptes** (le compte de l'utilisateur et le compte de
+  délégation — l'audit ne perd jamais l'acteur réel).
+
 ### Les comptes et les affectations
 
 - **la typologie des comptes** (D77) : technique (l'API),
@@ -168,9 +200,10 @@ restent à clore** — le sujet 3 les portera.
 
 ## Les points ouverts — le chantier du sujet 3
 
-1. **les comptes au quotidien** — la création du compte local, le
-   cycle de vie (l'invitation ? le mot de passe oublié ? le
-   verrouillage ?), la re-liaison D82 en pratique ;
+1. **les comptes au quotidien — le reste** : l'invitation et le
+   premier secret, le mot de passe oublié, le verrouillage (les
+   settings lockout/cooldown), la re-liaison et la fusion (D82) en
+   pratique — les propositions posées, à arbitrer ;
 2. **l'exploitation courante** — la sauvegarde (au-delà de la
    restauration D174), **la rotation des clés** (le flag D707),
    l'automatisation d'`encrypt` (le flag D708), la santé de

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -126,6 +126,39 @@ de partage** : la configuration déclare la structure (les groupes,
 les degrés, `directory:`), la base porte les appartenances —
 l'écran du groupe montre les deux faces.
 
+### Le quotidien du compte local (D720–D722)
+
+- **l'invitation** (D720) : le compte naît sans mot de passe — le
+  lien à durée limitée, l'utilisateur définit son secret,
+  l'administrateur ne le connaît jamais (D463/D703) ; le compte
+  n'entre pas tant que l'invitation n'est pas honorée ;
+- **le mot de passe oublié** : le lien de réinitialisation à durée
+  limitée ; le `renew` (D714) en est le pendant administratif —
+  toujours le lien, jamais une valeur ; **indisponible en SSO** (le
+  mot de passe n'est pas géré par l'application) ;
+- **le verrouillage** — **le volet local seul** : N échecs
+  verrouillent (`status: locked`), le déverrouillage par l'attente
+  ou l'administrateur ; les échecs tracés (D704) :
+
+```yaml
+settings:
+  application:
+    account:
+      lockout:    { mode: dynamic, type: integer,  value: 5 }     # les échecs
+      cooldown:   { mode: dynamic, type: duration, value: 15min } # l'attente
+      invitation: { mode: dynamic, type: duration, value: 48h }   # la validité des liens
+```
+
+- **le changement de mail** (D721) — l'UUID survit (D82) ; deux
+  chemins : **l'administrateur** (le changement direct, sans
+  vérification — tracé) ou **le profil** (la double validation en
+  chaîne : le clic depuis l'ancienne adresse, puis la validation
+  depuis la nouvelle) ;
+- **la fusion** (D722) — l'opération de l'administrateur : le
+  survivant désigné, l'autre **désactivé** (jamais supprimé) ; **la
+  perte éventuelle des historiques du compte désactivé est
+  assumée** — pas de re-parentage rétroactif des traces.
+
 ### Les opérations dédiées et la délégation (D714–D715)
 
 - les surfaces : **les utilisateurs** et **les groupes** en listes
@@ -254,14 +287,10 @@ restent à clore** — le sujet 3 les portera.
 
 ## Les points ouverts — le chantier du sujet 3
 
-1. **les comptes au quotidien — le reste** : l'invitation et le
-   premier secret, le mot de passe oublié, le verrouillage (les
-   settings lockout/cooldown), la re-liaison et la fusion (D82) en
-   pratique — les propositions posées, à arbitrer ;
-2. **l'exploitation courante** — la sauvegarde (au-delà de la
+1. **l'exploitation courante** — la sauvegarde (au-delà de la
    restauration D174), **la rotation des clés** (le flag D707),
    l'automatisation d'`encrypt` (le flag D708), la santé de
    l'instance en une vue ;
-3. **la télémétrie** (Q12–Q13) — ce qu'elle collecte, où elle vit
+2. **la télémétrie** (Q12–Q13) — ce qu'elle collecte, où elle vit
    (des entités du module d'administration ?), qui la voit, le lien
    au volet conseil (P9).

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -324,7 +324,10 @@ files d'attente (D686), les sessions actives, les connecteurs** (le
 `ping()` D621 — le feu tricolore) — disponible **en dashboard et en
 API** (la supervision externe interroge l'API) ; **l'état de santé
 du passif intégré** quand la réplication est active (le retard, le
-dernier passage, l'alerte au seuil — D626).
+dernier passage, l'alerte au seuil — D626). **L'état est en temps
+réel** (D732) : pas de période de rafraîchissement — l'état pousse
+(`refresh: live` — D249/D555) ; l'`every:` du `ping()` rythme la
+mesure, jamais l'affichage.
 
 ### Les journaux (D343)
 

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -250,6 +250,7 @@ en proposition, dans `environments/passive.yml`) :
 
 | le mode | la mécanique | le failback |
 |---|---|---|
+| `disabled` | **le défaut** — pas de passif, pas de synchronisation (D725) | — |
 | `brut` | **la copie de l'instance à intervalle régulier** — les fichiers des entités, les fichiers de configuration et la base | non |
 | `differentiel` | **la base au natif du moteur ou de l'infrastructure** (Syncytium ne gère pas la base) ; Syncytium synchronise **les fichiers des entités et de configuration** | non |
 | `synchronous` | **les actions historisées, transmises au passif, l'exécution confirmée supprime l'action en attente** (le patron de la file — D686) | **oui** — les actions du passif pendant l'incident reprennent le même chemin |

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -858,6 +858,7 @@ documentation) :
 | D730 | **La rotation des clés** : à chaque restauration (la naturalisation — la clé environnement+machine) et par la commande `syncytium rotate` (le patron de migrate, la progression suivie). | Voir §3.2c. |
 | D731 | **La santé** : les statuts, les files, les sessions, les connecteurs (ping) — en dashboard **et en API** (la supervision externe) ; l'état du passif intégré quand la réplication est active. | Voir §3.2c. |
 | D732 | **La santé en temps réel** (précise D731) : pas de période de rafraîchissement — l'état pousse (refresh: live D249/D555) ; l'every: du ping rythme la mesure, jamais l'affichage. | Voir §3.2c. |
+| D733 | **Le mail des faits marquants** (complète D731–D732) : le résumé d'exploitation au technicien — les utilisateurs connectés, les erreurs/warnings, les changements d'état de santé (liste ouverte) — au rythme choisi (l'every: calendaire) ; le template mail du socle surchargeable, l'évolution lue dans l'historique de l'état. | Voir §3.2c. |
 
 ---
 
@@ -6841,6 +6842,21 @@ mode temps réel de D249/D555 — `refresh: live`), le changement de
 statut paraît à l'instant au dashboard comme à l'API ; l'`every:` du
 `ping()` (D621) rythme la *mesure* côté connecteur, jamais
 l'*affichage* — la vue reflète le dernier état connu, en continu.
+
+**Le mail des faits marquants (D733 — complète D731–D732).** **« Le
+technicien doit pouvoir recevoir un mail, une fois par jour ou selon
+sa convenance, sur les faits marquants (liste des utilisateurs
+connectés, liste des erreurs/warnings, liste des changements d'état
+de santé, …) — un mail basé sur le statut de la santé vue
+précédemment et son évolution au cours de la journée. »** — le
+résumé d'exploitation : **la santé temps réel laisse une trace, le
+mail la résume** — les faits marquants de la période (les
+utilisateurs connectés, les erreurs et warnings des journaux D343,
+les changements d'état de santé D731, la liste ouverte), **au rythme
+choisi** (une fois par jour ou à convenance — l'`every:` calendaire
+D434). La mécanique n'invente rien : le template mail du socle
+(D723/D562 — surchargeable en configuration), l'envoi par le smtp
+(D628), l'évolution lue dans l'historique de l'état.
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -14927,6 +14943,11 @@ avant la synthèse Q16).
 - **2026-08-17 (suite 13)** — **La santé en temps réel (D732)** :
   pas de période de rafraîchissement — l'état pousse ; l'every: du
   ping rythme la mesure, jamais l'affichage.
+- **2026-08-17 (suite 14)** — **Le mail des faits marquants
+  (D733)** : le résumé d'exploitation au technicien, au rythme
+  choisi — la santé et son évolution dans la journée, les
+  utilisateurs connectés, les erreurs/warnings ; le template du
+  socle. administration.md mis au niveau.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -87,7 +87,7 @@ points ne sont pas validés). Les huit domaines en sont la carte —
 | 3 | **Le méta-schéma** — les règles, le comportement et le langage | Livré | D420–D436, Q60 (D570–D601) |
 | 4 | **Les surfaces** | Livré | D437–D569 |
 | 5 | **Les cas d'usage** — les mises en situation sur exemples concrets | À couvrir | Q59 |
-| 6 | **La rédaction de la documentation synthétique et détaillée** | En préparation | Q58 — glossaire, composants, hooks, types, connectors, mapping, rights |
+| 6 | **La rédaction de la documentation synthétique et détaillée** | En préparation | Q58 — glossaire, composants, hooks, types, connectors, mapping, rights, administration |
 | 7 | **Le choix de l'architecture technique** | À couvrir | Q7, Q47 |
 | 8 | **L'implémentation** | Après tout le reste | D314 |
 
@@ -107,8 +107,11 @@ documentation) :
    intrinsèque à l'inventaire validé (D697/D699–D701), le RGPD
    (D695–D698), l'audit des lectures (D702–D704), le chiffrement
    (D705–D708) ;
-3. **l'administration et l'exploitation** — à ouvrir ; le module
-   d'administration jamais décrit, la télémétrie (Q12–Q13) ;
+3. **l'administration et l'exploitation** — **ouvert**
+   (administration.md — D709) : l'acquis consolidé ; les quatre
+   points au chantier — le module d'administration, les comptes au
+   quotidien, l'exploitation courante (la rotation des clés,
+   l'automatisation d'encrypt), la télémétrie (Q12–Q13) ;
 4. **la migration et les versions** — largement soldée : le mapping
    entier (D646–D672), la jonction journal↔gestes storage (D673–D674
    — le critère structurel, la procédure en quatre temps), le retour
@@ -831,6 +834,7 @@ documentation) :
 | D706 | **Le chiffrement au repos — l'affaire du type** : le storage hors responsabilité de Syncytium (l'infrastructure) ; pas de facette — **un type chiffrant** (comme password) : le type qui a le pouvoir chiffre par ses fonctions de valeur (D683) et déclare ses capacités restantes. | Voir §3.2c. |
 | D707 | **Les clés obligatoirement chiffrées** (durcit D603 — solde le chiffrement) : les variables d'environnement (.env) jamais versionnées ; les commandes Syncytium chiffrent avant l'enregistrement (l'automatisation flaguée) ; le déchiffrement à l'usage ; le périmètre — les clés d'API, les mots de passe de connecteurs, les clés des types chiffrants (D706). | Voir §3.2c. |
 | D708 | **Les commandes encrypt/decrypt** (incarne D707) : `encrypt <variable> <clé>` chiffre et enregistre au .env (ou autre fichier) ; `decrypt <variable>` retourne la valeur (le débogage, la vérification d'un service). « Ces 2 commandes complètent la partie sécurité. » | Voir §3.2c. |
+| D709 | **`administration.md` créé** : le neuvième artefact préparatoire (Q58) — les actes d'administration et l'exploitation consolidés (les comptes/affectations, les sessions, les settings dynamiques, l'audit, le suivi des migrations, les opérations aux planchers, les environnements/journaux/supervision/secrets/versions, l'acquis télémétrie P9) + les quatre points du chantier du sujet 3 ; aucun contenu nouveau. | À la demande de l'auteur — la méthode des artefacts. |
 
 ---
 
@@ -14450,6 +14454,17 @@ avant la synthèse Q16).
   d'administration (les sessions D693, l'audit D704, la vue de
   migration D666, la rotation des clés D707), la télémétrie
   (Q12–Q13), les settings dynamiques (D588).
+- **2026-08-17 (suite 2)** — **Le sujet 3 ouvert —
+  administration.md créé (D709)** : le neuvième artefact — l'acquis
+  épars consolidé (les actes d'administration en base D341, le degré
+  administrator, les comptes D77/D82, les sessions D693, les
+  settings dynamiques D588, l'audit D704, le suivi des migrations
+  D666–D668, les opérations aux planchers D701, les environnements
+  D339–D343, la supervision D621/D625–D627, les secrets D707–D708,
+  les versions D332/D338–D340, la télémétrie P9) et les quatre
+  points du chantier (le module d'administration, les comptes au
+  quotidien, l'exploitation courante, la télémétrie Q12–Q13). Le
+  §1.2 mis au niveau.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -837,6 +837,10 @@ documentation) :
 | D709 | **`administration.md` créé** : le neuvième artefact préparatoire (Q58) — les actes d'administration et l'exploitation consolidés (les comptes/affectations, les sessions, les settings dynamiques, l'audit, le suivi des migrations, les opérations aux planchers, les environnements/journaux/supervision/secrets/versions, l'acquis télémétrie P9) + les quatre points du chantier du sujet 3 ; aucun contenu nouveau. | À la demande de l'auteur — la méthode des artefacts. |
 | D710 | **Le module d'administration** (le point 1 du sujet 3) : un seul module au **degré minimal administrator** (la double garde — l'affectation + le degré) ; les entrées (settings, comptes, sessions, audit, …) = un menu construit et maintenu dans Syncytium ; le module exploite les facettes de Syncytium (module, entités, menus, composants). | Le module migration (D666) demeure distinct (lecture notée). Voir §3.2c. |
 | D711 | **La migration au menu, les settings aux deux modes** (amende D710/D666) : l'entrée « migrations » au module d'administration — conditionnelle (disponible si `migrations:` défini, D662) ; les settings couvrent les statiques et les dynamiques (la consultation des deux, la surcharge des seuls dynamiques). | Voir §3.2c. |
+| D712 | **Le groupe administrator par défaut, l'accès à double entrée** (précise D699/D710) : le socle fournit le groupe d'office ; l'accès administrateur = le groupe ET la désignation individuelle de l'utilisateur. | Voir §3.2c. |
+| D713 | **La synchronisation selon le mode** : local = manuel par l'administrateur ; azure_ad = le groupe Syncytium associé à des groupes AD (la classe d'authentification récupère par le contrat directory D633), les comptes synchronisés en lecture seule ; sso = idem sans la gestion du mot de passe. | Les familles authentication et directory coopèrent. Voir §3.2c. |
+| D714 | **Les opérations dédiées du module** : `renew` (le changement forcé du mot de passe), `ban` (le bannissement sans suppression) — la liste ouverte. | Voir §3.2c. |
+| D715 | **La délégation** : agir à la place d'un utilisateur — les droits joués sont ceux de l'emprunté, **chaque trace porte les deux comptes** (l'utilisateur et le délégant). | Voir §3.2c. |
 
 ---
 
@@ -6491,6 +6495,65 @@ dynamiques. »** — deux amendements :
   paramètres statiques et dynamiques** (D588) — la consultation des
   deux, la surcharge des seuls dynamiques (le statique se change par
   une version, jamais par l'écran — la lecture consignée).
+
+**Le groupe administrateur par défaut — l'accès à double entrée
+(D712 — précise D699/D710).** **« La liste des groupes
+d'utilisateurs est définie dans la configuration (groups.yml). Un
+groupe "administrateur" est inclus, par défaut. Pour un utilisateur,
+les groupes d'appartenance permettent de gérer les droits. Pour
+l'administrateur, l'accès doit être à double entrée : par le groupe
+et par l'utilisateur. »** — le socle fournit **le groupe
+`administrator` d'office** (le catalogue = les hooks embarqués,
+D408 : groups.yml peut ne pas le déclarer, il existe) ; et **l'accès
+administrateur est à double entrée** : l'appartenance au groupe ne
+suffit pas — **l'utilisateur doit être individuellement désigné**
+(l'affectation nominative, l'acte d'administration D341) — le degré
+le plus haut ne se hérite jamais d'un seul geste.
+
+**La synchronisation des comptes selon le mode (D713 — finalise la
+création).** **« La liste des utilisateurs et sa synchronisation
+dépendent du mode d'authentification : pour une gestion locale, la
+création des comptes et l'affectation à un groupe sont manuelles et
+gérées par l'administrateur. Pour une gestion via un directory, un
+groupe d'utilisateurs est associé à un ou plusieurs groupes AD —
+Syncytium, via le connecteur d'authentification, récupère la liste
+des groupes associés aux groupes d'utilisateurs, puis la liste des
+utilisateurs associés à ces groupes ; les comptes utilisateurs (hors
+ceux créés par l'administrateur) sont accessibles en lecture seule,
+à l'exception de propriétés comme le mot de passe. Pour une gestion
+via sso, ça devrait couvrir la même chose qu'un directory sans la
+gestion du mot de passe. »** — les trois régimes :
+
+| le mode | la source des comptes | l'édition dans Syncytium |
+|---|---|---|
+| `local` | la création et l'affectation **manuelles** par l'administrateur | pleine |
+| `azure_ad` | **le groupe Syncytium associé à un ou plusieurs groupes AD** — la classe d'authentification récupère les groupes puis leurs utilisateurs (le contrat directory D633 : get_groups, get_users_from_group) | **lecture seule** (l'annuaire est maître) — sauf les propriétés hors annuaire |
+| `sso` | comme le directory | lecture seule — **sans la gestion du mot de passe** (le secret n'existe pas chez Syncytium) |
+
+*(La lecture consignée : le connecteur d'authentification s'appuie
+sur le contrat de la famille directory (D633) — les classes des deux
+familles coopèrent, comme file et storage en D636.)*
+
+**Les opérations dédiées du module — renew, ban… (D714).** **« Dans
+le module d'administration, nous pouvons voir les utilisateurs, les
+groupes d'utilisateurs, et nous pourrions avoir des opérations
+dédiées : `renew` (change ou force le changement de mot de passe),
+`ban` (pour bannir un utilisateur sans le supprimer)… »** — les
+surfaces standard (les utilisateurs, les groupes) et **les
+opérations propres au module** : `renew` (le changement forcé du mot
+de passe — le lien de réinitialisation, jamais la valeur), `ban`
+(le bannissement **sans suppression** — masquer, jamais détruire) —
+la liste ouverte (le « … »).
+
+**La délégation (D715).** **« Nous pouvons introduire une notion de
+délégation (prendre l'utilisation de l'application à la place d'un
+autre utilisateur). Toutes les actions seront tracées en précisant
+le compte de l'utilisateur et le compte de délégation. »** —
+l'emprunt d'identité maîtrisé : l'administrateur (ou le délégué
+autorisé) agit **à la place** d'un utilisateur — les droits joués
+sont ceux de l'utilisateur emprunté, et **chaque trace porte les
+deux comptes** (le compte de l'utilisateur et le compte de
+délégation — l'audit D62/D704 ne perd jamais l'acteur réel).
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -14522,6 +14585,16 @@ avant la synthèse Q16).
   d'administration (conditionnelle — si migrations: défini) — la
   lecture « module distinct » corrigée ; les settings couvrent
   statiques et dynamiques. administration.md mis au niveau.
+- **2026-08-17 (suite 5)** — **Les comptes au quotidien (D712–D715)**
+  : le groupe administrator par défaut + l'accès à double entrée ;
+  la synchronisation selon le mode (local manuel / azure_ad par
+  association de groupes en lecture seule / sso sans mot de passe) ;
+  les opérations renew/ban ; la délégation tracée aux deux comptes.
+  administration.md et rights.md mis au niveau. La remarque sur le
+  contrat directory vérifiée : D633 le porte (connectors.md) — pas
+  de décision « hook de directory » distincte, les classes des
+  familles sont les hooks (D619) ; la coopération
+  authentication↔directory désormais consignée (D713).
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -851,6 +851,12 @@ documentation) :
 | D723 | **Les mails du socle** (complète D720–D721) : l'invitation, la réinitialisation, la validation — des templates mail du socle (D562/D564, smtp D628, la langue de l'utilisateur) ; Syncytium les fournit par défaut, la configuration de l'application peut les redéfinir. | Voir §3.2c. |
 | D724 | **Le lien actif/passif** (précise D112–D114/D606) : le passif dormant ; trois modes — `brut` (la copie entière à intervalle, pas de failback), `differentiel` (la base au natif du moteur/de l'infra, Syncytium synchronise les fichiers — pas de failback), `synchronous` (les actions historisées, transmises, confirmées — le failback traité) ; la montée de version couverte par les trois. | L'écriture replication: en proposition. Voir §3.2c. |
 | D725 | **Le mode disabled** (complète D724) : le quatrième mode, le défaut — pas de passif, pas de synchronisation ; `replication: disabled \| brut \| differential \| synchronous`. | Voir §3.2c. |
+| D726 | **La réplication en configuration** : la déclaration dans environments/passive.yml — la forme courte (disabled) et la forme riche (mode: + every: ; synchronous sans every — le flux continu) ; les exemples gravés. | Voir §3.2c. |
+| D727 | **La sauvegarde** : duplicate_instance + les fichiers + la configuration, vers une destination précisée (un zip ou un espace de stockage) ; la rétention en jours — l'archive échue supprimée ; backup: en proposition. | Voir §3.2c. |
+| D728 | **La restauration — une image à sa propre vie** : l'adresse du point d'entrée fournie au geste, l'application restaurée devient une application comme les autres — le clonage assumé. | Voir §3.2c. |
+| D729 | **Les bibliothèques d'applications** : la sauvegarde en gabarit distribuable — le wizard d'initialisation (les paramètres clés, l'assistant des secrets enchaîné) **ou le storage sqlite natif** (l'application démarre seule) ; complète l'assistance d'installation. | Voir §3.2c. |
+| D730 | **La rotation des clés** : à chaque restauration (la naturalisation — la clé environnement+machine) et par la commande `syncytium rotate` (le patron de migrate, la progression suivie). | Voir §3.2c. |
+| D731 | **La santé** : les statuts, les files, les sessions, les connecteurs (ping) — en dashboard **et en API** (la supervision externe) ; l'état du passif intégré quand la réplication est active. | Voir §3.2c. |
 
 ---
 
@@ -6739,6 +6745,93 @@ synchronisation — la TPE qui s'en remet à ses sauvegardes (la
 proposition en cours) n'active rien ; l'écriture se complète :
 `replication: disabled | brut | differential | synchronous` (défaut
 `disabled`).
+
+**La réplication en configuration — les exemples par mode (D726).**
+**« Le mode de réplication se décline en configuration. »** — la
+déclaration dans `environments/passive.yml`, la forme courte pour le
+défaut, la forme riche au rythme :
+
+```yaml
+# environments/passive.yml — un mode par environnement passif
+replication: disabled                  # le défaut (D725) — pas de passif
+
+replication:
+  mode: brut                           # la copie entière (D724)
+  every: daily[02:00]                  # l'intervalle régulier (D434)
+
+replication:
+  mode: differential                   # la base au natif du moteur/de l'infra
+  every: 15min                         # les fichiers des entités + la configuration
+
+replication:
+  mode: synchronous                    # le journal d'actions au fil de l'eau
+                                       # (pas d'every: — le flux continu)
+```
+
+**La sauvegarde (D727 — arbitre la pièce 1).** **« La sauvegarde
+exploite la méthode duplicate_instance, recopie les fichiers et la
+configuration vers une destination précisée, dans un zip ou dans un
+espace de stockage. Nous conservons un historique sur un nombre de
+jours donné — au-delà de ce délai, les archives sont supprimées. »**
+— les trois matières (l'instance par `duplicate_instance` D680, les
+fichiers des entités, la configuration), **la destination
+précisée** — un zip ou un espace de stockage — et **la rétention en
+jours** (l'archive échue supprimée). *(L'écriture en proposition :*
+
+```yaml
+backup:
+  destination: zip:/backups/           # ou un connecteur de stockage
+  every: daily[01:00]
+  retention: 30d
+```
+
+*)*
+
+**La restauration — une image à sa propre vie (D728).** **« La
+restauration construira une image avec sa propre vie. Lors de la
+restauration, l'adresse du point d'entrée de l'application devra
+être fournie et l'application deviendra une application comme les
+autres. »** — la restauration ne remplace pas : elle **fait naître**
+— l'image restaurée vit sa propre vie (la nouvelle instance),
+**l'adresse du point d'entrée fournie au geste**, et l'application
+devient une application comme les autres — le clonage assumé (le
+staging depuis la production, la répétition d'une opération
+délicate, l'archive consultable).
+
+**Les bibliothèques d'applications (D729 — complète l'assistance
+d'installation).** **« La sauvegarde et la restauration peuvent être
+utilisées pour créer des bibliothèques d'applications, sous
+condition d'intégrer un wizard d'initialisation pour renseigner les
+paramètres clés de l'application (storage, …) ou de proposer un
+storage sqlite natif à l'application. Cela complète l'assistance
+d'installation sur la base des secrets. »** — la sauvegarde comme
+**gabarit distribuable** (le « Hello world ! » de D337 industrialisé,
+l'écosystème AGPL D68) : à la restauration d'une application de
+bibliothèque, **le wizard d'initialisation** demande les paramètres
+clés (le storage, les connecteurs — l'assistant des secrets D707/
+D708 enchaîné) — **ou le storage sqlite natif** épargne toute
+question : l'application démarre seule, la base embarquée.
+
+**La rotation des clés (D730 — arbitre la pièce 2).** **« La
+rotation des clés est déclenchée à chaque restauration ou via une
+commande comme tu le proposes. »** — les deux déclencheurs :
+**chaque restauration rote** (l'image nouvelle, la machine peut-être
+autre — la clé dérivée environnement + machine D603 l'impose de
+toute façon : la rotation est la naturalisation), et **la commande**
+`syncytium rotate` (le re-chiffrement du `.env` et des champs des
+types chiffrants — le patron de migrate, la progression suivie).
+
+**La santé — le dashboard et l'API (D731 — arbitre la pièce 4).**
+**« La santé intègre les statuts, les files, les sessions, … et les
+connecteurs. La santé est disponible sous un dashboard ou sur une
+API. Si présence d'un passif/actif, le dashboard intègre également
+l'état de santé du passif. »** — la vue d'office du module
+d'administration : les statuts, les files d'attente (D686), les
+sessions actives, **les connecteurs** (le `ping()` D621) — servie
+**en dashboard et en API** (la supervision externe — le Zabbix de la
+TPE interroge l'API) ; **l'état de santé du passif intégré** quand
+la réplication est active (D724) — le retard, le dernier passage,
+l'alerte au seuil.
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -14812,6 +14905,16 @@ avant la synthèse Q16).
   mis au niveau.
 - **2026-08-17 (suite 11)** — **Le mode disabled (D725)** : le
   quatrième mode, le défaut — pas de passif ; l'écriture complétée.
+- **2026-08-17 (suite 12)** — **L'exploitation courante soldée
+  (D726–D731)** : la réplication en configuration (les exemples par
+  mode), la sauvegarde (duplicate_instance + fichiers +
+  configuration, zip ou espace de stockage, la rétention en jours),
+  la restauration en image à sa propre vie (l'adresse du point
+  d'entrée, une application comme les autres), les bibliothèques
+  d'applications (le wizard d'initialisation ou le sqlite natif), la
+  rotation des clés (à chaque restauration + la commande), la santé
+  (dashboard et API, le passif intégré). administration.md mis au
+  niveau.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -849,6 +849,7 @@ documentation) :
 | D721 | **Le changement de mail** : l'UUID survit ; deux chemins — l'administrateur sans vérification (tracé), le profil à double validation (le clic depuis l'ancienne adresse puis la validation depuis la nouvelle). | Voir §3.2c. |
 | D722 | **La fusion** : l'opération de l'administrateur — le survivant désigné, l'autre désactivé (jamais supprimé) ; **la perte éventuelle des historiques du compte désactivé est assumée** — pas de re-parentage rétroactif. | Solde les comptes au quotidien. Voir §3.2c. |
 | D723 | **Les mails du socle** (complète D720–D721) : l'invitation, la réinitialisation, la validation — des templates mail du socle (D562/D564, smtp D628, la langue de l'utilisateur) ; Syncytium les fournit par défaut, la configuration de l'application peut les redéfinir. | Voir §3.2c. |
+| D724 | **Le lien actif/passif** (précise D112–D114/D606) : le passif dormant ; trois modes — `brut` (la copie entière à intervalle, pas de failback), `differentiel` (la base au natif du moteur/de l'infra, Syncytium synchronise les fichiers — pas de failback), `synchronous` (les actions historisées, transmises, confirmées — le failback traité) ; la montée de version couverte par les trois. | L'écriture replication: en proposition. Voir §3.2c. |
 
 ---
 
@@ -6697,6 +6698,38 @@ D217–D225) ; **Syncytium fournit ses mails par défaut** (le
 catalogue = les hooks embarqués — D408), **la configuration de
 l'application peut les redéfinir** (le patron du défaut remplacé par
 la déclaration — D186/D437).
+
+**Le lien actif/passif — le dormant et les trois modes (D724 —
+précise D112–D114/D606).** Le passif dormant confirmé (« je confirme
+que le passif est dormant ») — ni lecture ni service pendant la vie
+normale. **Et les trois modes de gestion** :
+
+- **`brut`** — **« la synchronisation est effectuée à intervalle
+  régulier via une copie de l'instance (fichiers des entités,
+  fichiers de configuration et base de données) — pas de
+  failback »** : la copie entière, simple et lourde, au rythme
+  d'`every:` ;
+- **`differentiel`** — **« cela dépend du moteur de base de données
+  ou de l'infrastructure : Syncytium ne gère pas la base mais
+  synchronise les fichiers des entités et les fichiers de
+  configuration — pas de failback »** : la réplication de la base
+  déléguée au natif (le streaming du moteur, l'infra), Syncytium ne
+  porte que les fichiers (les pièces jointes D384, la
+  configuration) ;
+- **`synchronous`** — **« les actions faites sur l'instance active
+  sont historisées, transmises à l'instance passive, et l'exécution
+  confirmée supprime l'action en attente (traite ainsi le
+  failback) »** : le journal d'actions expédié et confirmé (le
+  patron de la file d'attente D686) — **le seul mode qui traite le
+  failback** : les actions du passif pendant l'incident reprennent
+  le même chemin au retour.
+
+**« Une montée de version est couverte par les trois modes »** — la
+version voyage avec la synchronisation : la copie l'emporte (brut),
+les fichiers de configuration la portent (differentiel), l'action de
+migration s'expédie comme les autres (synchronous). *(L'écriture en
+proposition :* `replication: brut | differential | synchronous` *+
+le rythme à* `every:` *dans* `environments/passive.yml`*.)*
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -14762,6 +14795,12 @@ avant la synthèse Q16).
   mails de compte = des templates mail du socle, fournis par défaut,
   redéfinissables dans la configuration de l'application ; la langue
   de l'utilisateur. administration.md mis au niveau.
+- **2026-08-17 (suite 10)** — **Le lien actif/passif (D724)** : le
+  passif dormant confirmé ; les trois modes brut / differentiel
+  (la base au natif, Syncytium porte les fichiers) / synchronous
+  (les actions historisées-transmises-confirmées — le seul failback)
+  ; la montée de version couverte par les trois. administration.md
+  mis au niveau.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -835,6 +835,7 @@ documentation) :
 | D707 | **Les clés obligatoirement chiffrées** (durcit D603 — solde le chiffrement) : les variables d'environnement (.env) jamais versionnées ; les commandes Syncytium chiffrent avant l'enregistrement (l'automatisation flaguée) ; le déchiffrement à l'usage ; le périmètre — les clés d'API, les mots de passe de connecteurs, les clés des types chiffrants (D706). | Voir §3.2c. |
 | D708 | **Les commandes encrypt/decrypt** (incarne D707) : `encrypt <variable> <clé>` chiffre et enregistre au .env (ou autre fichier) ; `decrypt <variable>` retourne la valeur (le débogage, la vérification d'un service). « Ces 2 commandes complètent la partie sécurité. » | Voir §3.2c. |
 | D709 | **`administration.md` créé** : le neuvième artefact préparatoire (Q58) — les actes d'administration et l'exploitation consolidés (les comptes/affectations, les sessions, les settings dynamiques, l'audit, le suivi des migrations, les opérations aux planchers, les environnements/journaux/supervision/secrets/versions, l'acquis télémétrie P9) + les quatre points du chantier du sujet 3 ; aucun contenu nouveau. | À la demande de l'auteur — la méthode des artefacts. |
+| D710 | **Le module d'administration** (le point 1 du sujet 3) : un seul module au **degré minimal administrator** (la double garde — l'affectation + le degré) ; les entrées (settings, comptes, sessions, audit, …) = un menu construit et maintenu dans Syncytium ; le module exploite les facettes de Syncytium (module, entités, menus, composants). | Le module migration (D666) demeure distinct (lecture notée). Voir §3.2c. |
 
 ---
 
@@ -6445,6 +6446,32 @@ prennent forme :
 clé dérivée environnement + machine (D603) fait que le `.env` copié
 ailleurs reste muet ; le decrypt n'est utile qu'à qui a déjà la
 machine.)* **« Ces 2 commandes complètent la partie sécurité. »**
+
+**Le module d'administration — un seul module au degré administrator
+(D710 — ouvre le point 1 du sujet 3).** **« Le module
+d'administration est un seul module dont le degré minimal est
+administrator : les settings, la gestion des comptes, les sessions,
+l'audit, … Ces entrées sont des entrées d'un menu construit et
+maintenu dans Syncytium. Le module administration exploite les
+différentes facettes de Syncytium (le module, les entités, les
+menus, les composants graphiques, …). »** — les arbitrages :
+
+- **un seul module** — pas une constellation : les settings, la
+  gestion des comptes, les sessions, l'audit… sous un même toit (la
+  liste reste ouverte — le « … » de l'auteur) ; *(la lecture notée :
+  le module `migration` D666 demeure distinct — il n'entre pas dans
+  l'énumération)* ;
+- **le degré minimal `administrator`** — le premier module à
+  plancher : l'affectation ne suffit pas, le degré du groupe est
+  exigé (D699) — la double garde ;
+- **le menu construit et maintenu dans Syncytium** — les entrées
+  vivent avec le moteur (l'évolution du socle enrichit le menu sans
+  toucher aux applications) ;
+- **le dogfooding complet** : le module exploite les facettes de
+  Syncytium — le module (D416), les entités, les menus (D193/D440),
+  les composants graphiques (D437–D569) — le patron D666 confirmé et
+  généralisé : l'administration n'a rien de spécial, elle est une
+  application Syncytium.
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -14465,6 +14492,12 @@ avant la synthèse Q16).
   points du chantier (le module d'administration, les comptes au
   quotidien, l'exploitation courante, la télémétrie Q12–Q13). Le
   §1.2 mis au niveau.
+- **2026-08-17 (suite 3)** — **Le module d'administration (D710)** :
+  un seul module au degré minimal administrator, les entrées en menu
+  construit et maintenu dans Syncytium (settings, comptes, sessions,
+  audit, …), le dogfooding complet des facettes ; le module
+  migration demeure distinct (lecture notée). administration.md mis
+  au niveau.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -845,6 +845,9 @@ documentation) :
 | D717 | **Le groupe administrator associable au directory** (complète D712/D713) : la synchronisation vaut pour le groupe d'office — la double entrée demeure (la désignation individuelle reste l'acte local). | Voir §3.2c. |
 | D718 | **Le mode safe** : un mode d'exécution au lancement — le module administration seul, le compte administrateur principal et le mot de passe fixé à l'installation ; le filet quand l'annuaire/SSO/les droits sont morts ; tracé (jamais une porte dérobée). | Voir §3.2c. |
 | D719 | **Le détail user/group validé** : l'entité système user (login/email/… en rgpd: personal, account_type D77, origin, status active\|banned\|locked, admin — la double entrée, password local seul, les associations groups/modules) ; le groupe en configuration (degree, la composition, `directory:` — l'association AD) ; la fiche synchronisée en lecture seule sauf admin/modules/status ; historisée + audit. | « Je valide l'esquisse. » Voir §3.2c. |
+| D720 | **L'invitation, l'oubli, le verrouillage** (points 1–3) : validés — l'oubli et le renew indisponibles en SSO (le mot de passe hors application), le verrouillage local seul ; les settings lockout/cooldown/invitation dynamiques. | Voir §3.2c. |
+| D721 | **Le changement de mail** : l'UUID survit ; deux chemins — l'administrateur sans vérification (tracé), le profil à double validation (le clic depuis l'ancienne adresse puis la validation depuis la nouvelle). | Voir §3.2c. |
+| D722 | **La fusion** : l'opération de l'administrateur — le survivant désigné, l'autre désactivé (jamais supprimé) ; **la perte éventuelle des historiques du compte désactivé est assumée** — pas de re-parentage rétroactif. | Solde les comptes au quotidien. Voir §3.2c. |
 
 ---
 
@@ -6636,6 +6639,50 @@ déclare la structure (les groupes, les degrés, les associations
 d'annuaire par `directory:`), la base porte les appartenances ;
 l'écran du groupe montre les deux faces (le déclaré en lecture, les
 membres vivants).
+
+**L'invitation, l'oubli, le verrouillage (D720 — les points 1 à 3
+arbitrés).** Les trois validés, avec deux précisions :
+
+- **l'invitation** (« ok ») : le compte local ne naît jamais avec un
+  mot de passe posé par l'administrateur — le lien à durée limitée,
+  l'utilisateur définit son secret, le compte n'entre pas tant que
+  l'invitation n'est pas honorée ;
+- **le mot de passe oublié** (« ok ») — **« fonction indisponible
+  dans le cas du SSO, car le mot de passe n'est pas géré par
+  l'application »** : l'oubli et le `renew` (D714) n'existent que là
+  où Syncytium gère le secret — le volet local ; l'annuaire et
+  l'IdP portent leur propre politique ;
+- **le verrouillage** (« c'est valable que pour le local ») : les
+  settings `lockout`/`cooldown`/`invitation` en dynamique, les
+  échecs tracés (D704).
+
+**Le changement de mail — les deux chemins (D721 — amende le point
+4).** **« Chaque utilisateur a un uuid qui survit. Un utilisateur
+qui change de mail ne change pas d'uuid. Le changement de mail est
+une opération de l'administrateur (il change l'adresse sans
+vérification) ou une opération autorisée sur le profil de
+l'utilisateur (sous condition) : le changement depuis le profil
+n'est validé que sur l'envoi d'un mail suivi d'une validation en
+cliquant dessus par l'utilisateur d'origine (ancien email), puis
+validation depuis la nouvelle adresse. »** — l'UUID survit toujours
+(D82) ; **deux chemins** :
+
+1. **l'administrateur** — le changement direct, sans vérification
+   (l'acte tracé) ;
+2. **le profil** — la double validation en chaîne : le clic depuis
+   **l'ancienne** adresse (la preuve de possession), puis la
+   validation depuis **la nouvelle** (la preuve de réception) — le
+   détournement de compte impossible par un seul maillon.
+
+**La fusion — l'acte assumé (D722 — solde le point 4).** **« La
+fusion de 2 comptes est une opération de l'administrateur et elle
+s'accompagne de la désactivation d'un des 2 comptes — Syncytium
+assume éventuellement la perte des historiques liés au compte
+désactivé. »** — le survivant désigné, l'autre **désactivé** (jamais
+supprimé — D137) ; **la perte éventuelle des historiques du compte
+désactivé est assumée** — pas de re-parentage rétroactif des traces
+(l'histoire reste vraie : les actes anciens portent le compte qui
+les a faits) ; l'acte au degré administrator, audité.
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -14690,6 +14737,13 @@ avant la synthèse Q16).
   synchronisée sauf admin/modules/status, l'historisation, l'audit),
   la ligne de partage configuration/base. administration.md mis au
   niveau.
+- **2026-08-17 (suite 8)** — **Les comptes au quotidien soldés
+  (D720–D722)** : l'invitation/l'oubli/le verrouillage validés
+  (l'oubli indisponible en SSO, le verrouillage local seul) ; le
+  changement de mail aux deux chemins (l'admin sans vérification, le
+  profil à double validation ancien→nouveau) ; la fusion —
+  désactivation d'un des deux, la perte des historiques assumée.
+  administration.md mis au niveau.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -857,6 +857,7 @@ documentation) :
 | D729 | **Les bibliothèques d'applications** : la sauvegarde en gabarit distribuable — le wizard d'initialisation (les paramètres clés, l'assistant des secrets enchaîné) **ou le storage sqlite natif** (l'application démarre seule) ; complète l'assistance d'installation. | Voir §3.2c. |
 | D730 | **La rotation des clés** : à chaque restauration (la naturalisation — la clé environnement+machine) et par la commande `syncytium rotate` (le patron de migrate, la progression suivie). | Voir §3.2c. |
 | D731 | **La santé** : les statuts, les files, les sessions, les connecteurs (ping) — en dashboard **et en API** (la supervision externe) ; l'état du passif intégré quand la réplication est active. | Voir §3.2c. |
+| D732 | **La santé en temps réel** (précise D731) : pas de période de rafraîchissement — l'état pousse (refresh: live D249/D555) ; l'every: du ping rythme la mesure, jamais l'affichage. | Voir §3.2c. |
 
 ---
 
@@ -6832,6 +6833,14 @@ sessions actives, **les connecteurs** (le `ping()` D621) — servie
 TPE interroge l'API) ; **l'état de santé du passif intégré** quand
 la réplication est active (D724) — le retard, le dernier passage,
 l'alerte au seuil.
+
+**Le temps réel (D732 — précise D731).** **« L'état de l'application
+est un état en temps réel (pas de période de rafraîchissement). »**
+— la santé n'est jamais une photo périodique : **l'état pousse** (le
+mode temps réel de D249/D555 — `refresh: live`), le changement de
+statut paraît à l'instant au dashboard comme à l'API ; l'`every:` du
+`ping()` (D621) rythme la *mesure* côté connecteur, jamais
+l'*affichage* — la vue reflète le dernier état connu, en continu.
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -14915,6 +14924,9 @@ avant la synthèse Q16).
   rotation des clés (à chaque restauration + la commande), la santé
   (dashboard et API, le passif intégré). administration.md mis au
   niveau.
+- **2026-08-17 (suite 13)** — **La santé en temps réel (D732)** :
+  pas de période de rafraîchissement — l'état pousse ; l'every: du
+  ping rythme la mesure, jamais l'affichage.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -836,6 +836,7 @@ documentation) :
 | D708 | **Les commandes encrypt/decrypt** (incarne D707) : `encrypt <variable> <clé>` chiffre et enregistre au .env (ou autre fichier) ; `decrypt <variable>` retourne la valeur (le débogage, la vérification d'un service). « Ces 2 commandes complètent la partie sécurité. » | Voir §3.2c. |
 | D709 | **`administration.md` créé** : le neuvième artefact préparatoire (Q58) — les actes d'administration et l'exploitation consolidés (les comptes/affectations, les sessions, les settings dynamiques, l'audit, le suivi des migrations, les opérations aux planchers, les environnements/journaux/supervision/secrets/versions, l'acquis télémétrie P9) + les quatre points du chantier du sujet 3 ; aucun contenu nouveau. | À la demande de l'auteur — la méthode des artefacts. |
 | D710 | **Le module d'administration** (le point 1 du sujet 3) : un seul module au **degré minimal administrator** (la double garde — l'affectation + le degré) ; les entrées (settings, comptes, sessions, audit, …) = un menu construit et maintenu dans Syncytium ; le module exploite les facettes de Syncytium (module, entités, menus, composants). | Le module migration (D666) demeure distinct (lecture notée). Voir §3.2c. |
+| D711 | **La migration au menu, les settings aux deux modes** (amende D710/D666) : l'entrée « migrations » au module d'administration — conditionnelle (disponible si `migrations:` défini, D662) ; les settings couvrent les statiques et les dynamiques (la consultation des deux, la surcharge des seuls dynamiques). | Voir §3.2c. |
 
 ---
 
@@ -6472,6 +6473,24 @@ menus, les composants graphiques, …). »** — les arbitrages :
   les composants graphiques (D437–D569) — le patron D666 confirmé et
   généralisé : l'administration n'a rien de spécial, elle est une
   application Syncytium.
+
+**La migration au menu, les settings aux deux modes (D711 — amende
+D710 et D666).** **« La migration est à inclure dans l'énumération.
+Cette partie est disponible si `migrations` est bien défini dans la
+configuration. Les settings couvrent les paramètres statiques et
+dynamiques. »** — deux amendements :
+
+- **la migration entre au module d'administration** : le « module
+  migration » de D666 se relit — ses entités (la couverture, les
+  rejets, le suivi historisé D668) vivent au module
+  d'administration, l'entrée « migrations » de son menu ; **l'entrée
+  est conditionnelle** : disponible seulement si `migrations:` est
+  défini dans la configuration (D662) — le menu du socle s'adapte à
+  la déclaration ;
+- **les settings aux deux modes** : l'entrée couvre **les
+  paramètres statiques et dynamiques** (D588) — la consultation des
+  deux, la surcharge des seuls dynamiques (le statique se change par
+  une version, jamais par l'écran — la lecture consignée).
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -14498,6 +14517,11 @@ avant la synthèse Q16).
   audit, …), le dogfooding complet des facettes ; le module
   migration demeure distinct (lecture notée). administration.md mis
   au niveau.
+- **2026-08-17 (suite 4)** — **La migration au menu, les settings
+  aux deux modes (D711)** : l'entrée migrations au module
+  d'administration (conditionnelle — si migrations: défini) — la
+  lecture « module distinct » corrigée ; les settings couvrent
+  statiques et dynamiques. administration.md mis au niveau.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -848,6 +848,7 @@ documentation) :
 | D720 | **L'invitation, l'oubli, le verrouillage** (points 1–3) : validés — l'oubli et le renew indisponibles en SSO (le mot de passe hors application), le verrouillage local seul ; les settings lockout/cooldown/invitation dynamiques. | Voir §3.2c. |
 | D721 | **Le changement de mail** : l'UUID survit ; deux chemins — l'administrateur sans vérification (tracé), le profil à double validation (le clic depuis l'ancienne adresse puis la validation depuis la nouvelle). | Voir §3.2c. |
 | D722 | **La fusion** : l'opération de l'administrateur — le survivant désigné, l'autre désactivé (jamais supprimé) ; **la perte éventuelle des historiques du compte désactivé est assumée** — pas de re-parentage rétroactif. | Solde les comptes au quotidien. Voir §3.2c. |
+| D723 | **Les mails du socle** (complète D720–D721) : l'invitation, la réinitialisation, la validation — des templates mail du socle (D562/D564, smtp D628, la langue de l'utilisateur) ; Syncytium les fournit par défaut, la configuration de l'application peut les redéfinir. | Voir §3.2c. |
 
 ---
 
@@ -6683,6 +6684,19 @@ supprimé — D137) ; **la perte éventuelle des historiques du compte
 désactivé est assumée** — pas de re-parentage rétroactif des traces
 (l'histoire reste vraie : les actes anciens portent le compte qui
 les a faits) ; l'acte au degré administrator, audité.
+
+**Les mails du socle, surchargeables (D723 — complète D720–D721).**
+**« La construction des mails utilise bien sûr le socle de Syncytium
+et ils peuvent être définis dans la configuration de l'application.
+Par défaut, Syncytium fournit ses mails. »** — l'invitation, la
+réinitialisation, la validation de changement d'adresse : **des
+templates `mail` du socle** (D562/D564 — le mustache + markdown
+rendu en HTML, l'envoi par le connecteur smtp D628, la déclinaison
+par langue D559 — le mail part dans la langue de l'utilisateur
+D217–D225) ; **Syncytium fournit ses mails par défaut** (le
+catalogue = les hooks embarqués — D408), **la configuration de
+l'application peut les redéfinir** (le patron du défaut remplacé par
+la déclaration — D186/D437).
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -14744,6 +14758,10 @@ avant la synthèse Q16).
   profil à double validation ancien→nouveau) ; la fusion —
   désactivation d'un des deux, la perte des historiques assumée.
   administration.md mis au niveau.
+- **2026-08-17 (suite 9)** — **Les mails du socle (D723)** : les
+  mails de compte = des templates mail du socle, fournis par défaut,
+  redéfinissables dans la configuration de l'application ; la langue
+  de l'utilisateur. administration.md mis au niveau.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -844,6 +844,7 @@ documentation) :
 | D716 | **Keycloak** (enrichit D692) : une classe de la famille authentication aux côtés de local/azure_ad/sso — le visage concret du volet SSO (l'IdP OIDC open source) ; le contrat en deux gestes le couvre sans changement. | La lecture famille→classe (D613/D619). Voir §3.2c. |
 | D717 | **Le groupe administrator associable au directory** (complète D712/D713) : la synchronisation vaut pour le groupe d'office — la double entrée demeure (la désignation individuelle reste l'acte local). | Voir §3.2c. |
 | D718 | **Le mode safe** : un mode d'exécution au lancement — le module administration seul, le compte administrateur principal et le mot de passe fixé à l'installation ; le filet quand l'annuaire/SSO/les droits sont morts ; tracé (jamais une porte dérobée). | Voir §3.2c. |
+| D719 | **Le détail user/group validé** : l'entité système user (login/email/… en rgpd: personal, account_type D77, origin, status active\|banned\|locked, admin — la double entrée, password local seul, les associations groups/modules) ; le groupe en configuration (degree, la composition, `directory:` — l'association AD) ; la fiche synchronisée en lecture seule sauf admin/modules/status ; historisée + audit. | « Je valide l'esquisse. » Voir §3.2c. |
 
 ---
 
@@ -6595,6 +6596,46 @@ verrouillés par erreur) :
 - *(la lecture notée : le mode safe est tracé — l'audit D704
   enregistre le lancement et les actes, la porte de secours n'est
   jamais une porte dérobée).*
+
+**Le détail de l'utilisateur et du groupe (D719 — « je valide
+l'esquisse »).** Les deux entités arrêtées :
+
+```yaml
+# l'entité système user — définie, construite et maintenue par
+# Syncytium (D666/D704), jamais déclarée par le technicien
+user:
+  label: "{first_name} {last_name}"
+  fields:
+    login:        { type: text, rgpd: personal }      # la clé d'unicité (D82)
+    email:        { type: email, rgpd: personal }
+    first_name:   { type: text, rgpd: personal }
+    last_name:    { type: text, rgpd: personal }
+    language:     reference                            # la langue → le fuseau (D217–D225)
+    account_type: enum [technical, internal, customer] # la typologie (D77)
+    origin:       reference                            # le connecteur d'authentification (D713)
+    status:       enum [active, banned, locked]        # ban (D714), le verrouillage
+    admin:        boolean                              # la désignation individuelle (D712)
+    password:     password                             # le local seul — jamais relu (D463)
+    groups:       association with group               # l'affectation en base (D341)
+    modules:      association with module              # l'affectation en base (D416)
+
+# groups.yml — la configuration (le déclaré)
+groups:
+  managers:
+    degree: manager                    # D699
+    groups: [sales_team, accounting]   # la composition acyclique (D414)
+    directory: ["GRP-AD-Managers"]     # l'association aux groupes AD (D713/D717)
+```
+
+Les régimes consignés avec l'esquisse : **la fiche synchronisée en
+lecture seule** (D713 — sauf les propriétés hors annuaire : `admin`,
+`modules`, `status`) ; l'UUID interne hors déclaration (D142) ;
+l'entité **historisée** (qui a donné quel droit, quand) et ses
+lectures à l'audit ; **la ligne de partage** — la configuration
+déclare la structure (les groupes, les degrés, les associations
+d'annuaire par `directory:`), la base porte les appartenances ;
+l'écran du groupe montre les deux faces (le déclaré en lecture, les
+membres vivants).
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -14643,6 +14684,12 @@ avant la synthèse Q16).
   safe — le lancement dédié, le module administration seul, le
   compte principal au mot de passe d'installation, tracé.
   administration.md, rights.md et connectors.md mis au niveau.
+- **2026-08-17 (suite 7)** — **Le détail user/group validé (D719)** :
+  les deux esquisses gravées (l'entité système user, le groupe en
+  configuration avec directory:), les régimes (lecture seule
+  synchronisée sauf admin/modules/status, l'historisation, l'audit),
+  la ligne de partage configuration/base. administration.md mis au
+  niveau.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -841,6 +841,9 @@ documentation) :
 | D713 | **La synchronisation selon le mode** : local = manuel par l'administrateur ; azure_ad = le groupe Syncytium associé à des groupes AD (la classe d'authentification récupère par le contrat directory D633), les comptes synchronisés en lecture seule ; sso = idem sans la gestion du mot de passe. | Les familles authentication et directory coopèrent. Voir §3.2c. |
 | D714 | **Les opérations dédiées du module** : `renew` (le changement forcé du mot de passe), `ban` (le bannissement sans suppression) — la liste ouverte. | Voir §3.2c. |
 | D715 | **La délégation** : agir à la place d'un utilisateur — les droits joués sont ceux de l'emprunté, **chaque trace porte les deux comptes** (l'utilisateur et le délégant). | Voir §3.2c. |
+| D716 | **Keycloak** (enrichit D692) : une classe de la famille authentication aux côtés de local/azure_ad/sso — le visage concret du volet SSO (l'IdP OIDC open source) ; le contrat en deux gestes le couvre sans changement. | La lecture famille→classe (D613/D619). Voir §3.2c. |
+| D717 | **Le groupe administrator associable au directory** (complète D712/D713) : la synchronisation vaut pour le groupe d'office — la double entrée demeure (la désignation individuelle reste l'acte local). | Voir §3.2c. |
+| D718 | **Le mode safe** : un mode d'exécution au lancement — le module administration seul, le compte administrateur principal et le mot de passe fixé à l'installation ; le filet quand l'annuaire/SSO/les droits sont morts ; tracé (jamais une porte dérobée). | Voir §3.2c. |
 
 ---
 
@@ -6554,6 +6557,44 @@ autorisé) agit **à la place** d'un utilisateur — les droits joués
 sont ceux de l'utilisateur emprunté, et **chaque trace porte les
 deux comptes** (le compte de l'utilisateur et le compte de
 délégation — l'audit D62/D704 ne perd jamais l'acteur réel).
+
+**Keycloak (D716 — enrichit D692).** **« Nous pourrions ajouter une
+famille de connecteurs keycloak (qui joue le jeu du SSO). »** — la
+lecture consignée dans notre vocabulaire (D613/D619 — le type est la
+famille, la classe le remplit) : **`keycloak` entre comme une classe
+de la famille `authentication`**, aux côtés de `local`, `azure_ad`
+et `sso` — le visage concret du volet SSO (Keycloak, l'IdP OIDC open
+source — l'affinité AGPL naturelle) ; le contrat en deux gestes
+(D692) le couvre sans changement.
+
+**Le groupe administrator associable au directory (D717 — complète
+D712/D713).** **« Le groupe administrator peut être associé à un
+groupe de directory. »** — l'association de D713 vaut aussi pour le
+groupe fourni d'office : les administrateurs peuvent se synchroniser
+depuis l'annuaire — **la double entrée demeure** (D712) : le groupe
+synchronisé apporte l'appartenance, la désignation individuelle
+reste l'acte local.
+
+**Le mode safe — la porte de secours (D718).** **« Nous devons
+garder une porte d'accès par un compte administrateur safe,
+accessible sous condition comme un lancement de l'application en
+mode safe. Le mode safe est un mode d'exécution permettant l'accès à
+l'application uniquement au module administration, avec le compte
+administrateur principal et le mot de passe que nous avons fixé à
+l'installation de l'application. »** — le filet quand tout le reste
+est mort (l'annuaire injoignable, le SSO cassé, les droits
+verrouillés par erreur) :
+
+- **un mode d'exécution** — le lancement de l'application en mode
+  safe (jamais un état atteignable depuis l'application vivante) ;
+- **le périmètre : le module administration seul** — aucune donnée
+  métier servie ;
+- **l'accès : le compte administrateur principal** et **le mot de
+  passe fixé à l'installation** de l'application (le patron des
+  secrets D707 — hors annuaire, hors configuration versionnée) ;
+- *(la lecture notée : le mode safe est tracé — l'audit D704
+  enregistre le lancement et les actes, la porte de secours n'est
+  jamais une porte dérobée).*
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -14595,6 +14636,13 @@ avant la synthèse Q16).
   de décision « hook de directory » distincte, les classes des
   familles sont les hooks (D619) ; la coopération
   authentication↔directory désormais consignée (D713).
+- **2026-08-17 (suite 6)** — **Keycloak, l'administrateur au
+  directory, le mode safe (D716–D718)** : keycloak en classe
+  d'authentification (la lecture famille→classe) ; le groupe
+  administrator synchronisable (la double entrée demeure) ; le mode
+  safe — le lancement dédié, le module administration seul, le
+  compte principal au mot de passe d'installation, tracé.
+  administration.md, rights.md et connectors.md mis au niveau.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -850,6 +850,7 @@ documentation) :
 | D722 | **La fusion** : l'opération de l'administrateur — le survivant désigné, l'autre désactivé (jamais supprimé) ; **la perte éventuelle des historiques du compte désactivé est assumée** — pas de re-parentage rétroactif. | Solde les comptes au quotidien. Voir §3.2c. |
 | D723 | **Les mails du socle** (complète D720–D721) : l'invitation, la réinitialisation, la validation — des templates mail du socle (D562/D564, smtp D628, la langue de l'utilisateur) ; Syncytium les fournit par défaut, la configuration de l'application peut les redéfinir. | Voir §3.2c. |
 | D724 | **Le lien actif/passif** (précise D112–D114/D606) : le passif dormant ; trois modes — `brut` (la copie entière à intervalle, pas de failback), `differentiel` (la base au natif du moteur/de l'infra, Syncytium synchronise les fichiers — pas de failback), `synchronous` (les actions historisées, transmises, confirmées — le failback traité) ; la montée de version couverte par les trois. | L'écriture replication: en proposition. Voir §3.2c. |
+| D725 | **Le mode disabled** (complète D724) : le quatrième mode, le défaut — pas de passif, pas de synchronisation ; `replication: disabled \| brut \| differential \| synchronous`. | Voir §3.2c. |
 
 ---
 
@@ -6730,6 +6731,14 @@ les fichiers de configuration la portent (differentiel), l'action de
 migration s'expédie comme les autres (synchronous). *(L'écriture en
 proposition :* `replication: brut | differential | synchronous` *+
 le rythme à* `every:` *dans* `environments/passive.yml`*.)*
+
+**Le mode disabled (D725 — complète D724).** **« Il y a un mode
+`disabled` pour ne pas activer le mode actif/passif, bien sûr. »** —
+le quatrième mode, **le défaut** : pas de passif, pas de
+synchronisation — la TPE qui s'en remet à ses sauvegardes (la
+proposition en cours) n'active rien ; l'écriture se complète :
+`replication: disabled | brut | differential | synchronous` (défaut
+`disabled`).
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -14801,6 +14810,8 @@ avant la synthèse Q16).
   (les actions historisées-transmises-confirmées — le seul failback)
   ; la montée de version couverte par les trois. administration.md
   mis au niveau.
+- **2026-08-17 (suite 11)** — **Le mode disabled (D725)** : le
+  quatrième mode, le défaut — pas de passif ; l'écriture complétée.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -14443,6 +14443,13 @@ avant la synthèse Q16).
 - **2026-08-16 (suite 63)** — **LE SUJET 2 (LA SÉCURITÉ ET LES
   DROITS) EST SOLDÉ** (D690–D708) — le §1.2 mis au niveau. Reste le
   sujet 3 : l'administration et l'exploitation.
+- **2026-08-17** — **La PR #32 fusionnée (vérifiée)** : « La
+  sécurité et les droits — le sujet 2 soldé (D690–D708) », 13
+  commits sur develop. Pause — la prochaine séance ouvrira le sujet
+  3 (l'administration et l'exploitation) : le module
+  d'administration (les sessions D693, l'audit D704, la vue de
+  migration D666, la rotation des clés D707), la télémétrie
+  (Q12–Q13), les settings dynamiques (D588).
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -115,7 +115,7 @@ d'une classe vérifiée au chargement :
 | `location` | le géocodage | ban (Addok), nominatim | D294 |
 | `webhook` | **« un point d'entrée dans les différents appels d'api versionnés »** — get, put, post, delete (D609) | — | D623–D624 |
 | `siren` | la vérification des identifiants | — | D611/D623 |
-| `authentication` | l'identité — l'utilisateur et l'API (D692) | local, azure_ad, sso | D418/D692 |
+| `authentication` | l'identité — l'utilisateur et l'API (D692) | local, azure_ad, sso, keycloak (D716) | D418/D692/D716 |
 
 *(La reprise n'est pas une famille : le connecteur de reprise
 (D175–D179) s'appuie sur les familles existantes — le storage en
@@ -261,8 +261,9 @@ l'API ne porte pas de session — chaque requête porte sa preuve (le
 compte technique D77). **La garde du webhook (D642) appelle ce même
 `verify`** — rien de dédié. Les classes : `local` (le haché, les
 clés d'API), `azure_ad` (le bind, le bearer Entra), `sso` (l'OIDC,
-la signature du jeton) — chaque classe déclare ce qu'elle sait
-vérifier ; le multi-connecteurs sert l'étanchéité par canal (D77 —
+la signature du jeton), `keycloak` (D716 — l'IdP OIDC open source,
+le visage concret du volet SSO) — chaque classe déclare ce qu'elle
+sait vérifier ; le multi-connecteurs sert l'étanchéité par canal (D77 —
 l'AD pour les internes, le local pour les clients).
 
 ### `siren` (D639)

--- a/docs/rights.md
+++ b/docs/rights.md
@@ -107,6 +107,9 @@ d'action — on contrôle qui appuie, pas ce que l'acte écrit.
   **et** la désignation individuelle de l'utilisateur ;
 - **la délégation** (D715) : agir à la place d'un utilisateur — les
   droits de l'emprunté, la trace aux deux comptes ;
+- **le mode safe** (D718) : le lancement dédié — le module
+  administration seul, le compte administrateur principal au mot de
+  passe d'installation ; tracé, jamais une porte dérobée ;
 - **le module restreint** (D190/D416) : l'affectation
   utilisateur↔module ouvre une surface — elle n'étend jamais un
   droit.
@@ -147,6 +150,8 @@ clé d'unicité (D82). **Les quatre volets à porter** :
 3. **`sso`** — la délégation : la redirection OIDC, le ticket au
    retour, la signature du jeton validée — l'utilisateur ne confie
    jamais son secret à Syncytium ;
+   *(`keycloak` — D716 — en est le visage concret : l'IdP OIDC open
+   source, une classe aux côtés de `sso`.)*
 4. **l'API** — la preuve au porteur : la clé d'API ou le bearer dans
    chaque requête (le 401 en défi), le compte technique (D77), pas
    de session ; **la garde du webhook (D642) appelle le même

--- a/docs/rights.md
+++ b/docs/rights.md
@@ -102,6 +102,11 @@ d'action — on contrôle qui appuie, pas ce que l'acte écrit.
   acyclique, la multi-appartenance naturelle (D414) ;
 - **les affectations vivent en base** — l'acte d'administration
   (D341), jamais dans le dépôt ;
+- **le groupe `administrator` par défaut** (D712) — fourni par le
+  socle ; **l'accès administrateur à double entrée** : le groupe
+  **et** la désignation individuelle de l'utilisateur ;
+- **la délégation** (D715) : agir à la place d'un utilisateur — les
+  droits de l'emprunté, la trace aux deux comptes ;
 - **le module restreint** (D190/D416) : l'affectation
   utilisateur↔module ouvre une surface — elle n'étend jamais un
   droit.


### PR DESCRIPTION
## L'administration et l'exploitation — le sujet 3 en grande partie soldé (D709–D733)

**Le sujet 3 de la passe de complétude est ouvert et largement couvert** : 25 décisions, un nouvel artefact documentaire (`administration.md` — le neuvième), et il ne reste que la télémétrie (Q12–Q13).

### administration.md créé (D709)

Le neuvième artefact, à la méthode des précédents : la doctrine (les actes en base D341, le degré `administrator`, le module porté par Syncytium), l'acquis épars consolidé (les comptes, les sessions, les settings, l'audit, les migrations, les environnements, les journaux, la supervision, les secrets, les versions, l'acquis télémétrie P9).

### Le module d'administration (D710–D711)

**Un seul module au degré minimal `administrator`** — la double garde (l'affectation + le degré) ; les entrées en **menu construit et maintenu dans Syncytium** : les settings (statiques et dynamiques), les comptes, les sessions, l'audit, **les migrations** (l'entrée conditionnelle — si `migrations:` est défini) ; le dogfooding complet — l'administration est une application Syncytium.

### Les comptes (D712–D723)

- **Le groupe `administrator` d'office** et **l'accès à double entrée** (le groupe + la désignation individuelle) ; le groupe associable à un groupe du directory (D717).
- **La synchronisation selon le mode** (D713) : local (manuel), azure_ad (les groupes Syncytium associés aux groupes AD — les familles `authentication` et `directory` coopèrent ; les comptes en lecture seule), sso (idem sans mot de passe) ; **Keycloak** en classe d'authentification (D716).
- **Le mode safe** (D718) : le lancement dédié — le module administration seul, le compte principal au mot de passe d'installation ; tracé, jamais une porte dérobée.
- **Le détail user/group validé** (D719) : l'entité système `user` (le statut active/banned/locked, le drapeau `admin`, les associations), le groupe en configuration (`degree:`, `directory:`).
- **Le quotidien** (D720–D723) : l'invitation (le compte naît sans mot de passe), l'oubli (indisponible en SSO), le verrouillage (le local seul, les settings dynamiques), le changement de mail (la double validation ancien→nouveau), la fusion (la désactivation d'un des deux, la perte des historiques assumée), les opérations `renew`/`ban`, **la délégation** (la trace aux deux comptes), **les mails du socle** surchargeables.

### L'exploitation (D724–D733)

- **Le lien actif/passif** (D724–D726) : le passif dormant ; les quatre modes `disabled` (défaut) / `brut` / `differential` / `synchronous` (le seul failback — les actions historisées-transmises-confirmées) ; la montée de version couverte par tous ; les exemples de configuration gravés.
- **La sauvegarde et la restauration** (D727–D729) : `duplicate_instance` + les fichiers + la configuration vers un zip ou un espace de stockage, la rétention en jours ; **la restauration = une image à sa propre vie** (l'adresse du point d'entrée fournie) ; **les bibliothèques d'applications** (le wizard d'initialisation ou le sqlite natif).
- **La rotation des clés** (D730) : à chaque restauration et par `syncytium rotate`.
- **La santé** (D731–D733) : les statuts, les files, les sessions, les connecteurs — **en dashboard et en API, en temps réel** (l'état pousse) ; le passif intégré ; **le mail des faits marquants** au rythme choisi.

### Les documents

`administration.md` créé et nourri à chaque décision ; `rights.md` (keycloak, le mode safe, la délégation, le groupe d'office), `connectors.md` (keycloak) tenus au niveau ; le §1.2 à jour.

### Ce qui reste

**La télémétrie** (Q12–Q13 — le dernier point de la passe de complétude) — puis les cas d'usage (Q59) et la documentation (Q58).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
