### PR TITLE
Le chantier du thème — les styles, les thèmes et leur hook (D752–D755)

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -115,6 +115,7 @@ user:
     first_name:   { type: text, rgpd: personal }
     last_name:    { type: text, rgpd: personal }
     language:     reference                            # la langue → le fuseau (D217–D225)
+    theme:        reference                            # le thème choisi (D753 — parmi les visibles)
     account_type: enum [technical, internal, customer] # la typologie (D77)
     origin:       reference                            # le connecteur d'authentification (D713)
     status:       enum [active, banned, locked]        # ban (D714), le verrouillage

--- a/docs/composants.md
+++ b/docs/composants.md
@@ -300,8 +300,10 @@ gui:
    `lines` (les lignes visibles), `icon` (l'icône du déploiement),
    `label` (le libellé par langue — « Voir plus ») ; absent, le moteur
    applique son défaut traduit (thème E) ; **`style:`** — « la fonte,
-   la taille et sa mise en forme » (D536) : le défaut au **style
-   global de l'application**, la surcharge à la cascade D461 (*en
+   la taille et sa mise en forme » (D536) : le défaut au **thème
+   choisi par l'utilisateur** (D752–D755 — le thème combine des
+   styles du catalogue, le style porte le HTML des types + le CSS3),
+   la surcharge à la cascade D461 (*en
    proposition : `style: { font: Roboto, size: 14px, format: [bold,
    italic] }` — le size intérieur = la police, D458 départage*) ;
 6. **Items** — aucun ;

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -15412,6 +15412,12 @@ avant la synthèse Q16).
   surcharge) ; le hook de style = la sixième famille (le thème = une
   combinaison de styles, la structure non généralisable, le
   complément du hook d'affichage). hooks.md mis au niveau.
+- **2026-08-18 (suite 5)** — **Le tour des artefacts pour le thème**
+  (« as-tu mis à jour tous les items ? ») : glossaire.md (les
+  entrées Style et Thème créées), composants.md (le style: raccordé
+  au thème choisi — D536 relu), rights.md (le thème aux droits) —
+  hooks.md et administration.md l'étaient déjà. Le chantier du thème
+  est couvert dans les six documents concernés.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -15279,6 +15279,10 @@ avant la synthèse Q16).
   le backup au menu + la restauration en commande. **La
   vérification des piliers et des concepts est complète.**
   administration.md, rights.md et telemetry.md mis au niveau.
+- **2026-08-17 (suite 28)** — **La PR #34 fusionnée (vérifiée)** :
+  « la passe de complétude soldée (D734–D751) », 14 commits sur
+  develop. **La deuxième publication develop→main demandée** (la
+  première : la PR #27).
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -879,6 +879,7 @@ Q58) :
 | D750 | **logs.yml harmonisé** (corrige D737) : le nom de D342 prime — `logs.yml` partout. | Voir §3.2c. |
 | D751 | **La santé et le backup au menu** (huit entrées) ; **la restauration = une commande interne** (le geste vit hors de l'application). | Voir §3.2c. |
 | D752 | **Le catalogue de styles** (ouvre le chantier du thème) : « au même titre que les composants graphiques, Syncytium propose un ou plusieurs styles » — les styles embarqués du socle (D408), le choix + la personnalisation par la couche thème (D63 : les couleurs, les fontes, le logo, la marque) ; la vérification : le registre ne portait que des touches éparses (D63/D191/D346/D443/D536). | La forme de la déclaration à arbitrer. Voir §3.2c. |
+| D753 | **Le multi-thèmes** (amende la proposition) : plusieurs thèmes par application, **le choix au profil de l'utilisateur** (comme la langue) ; le dossier `themes/` + la déclaration explicite dans la définition de la version (D415/D644) ; **le thème = un objet comme les autres, avec les droits** (la confidentialité — le choix n'offre que le visible). | themes.yml et l'écriture du thème en proposition ; le premier déclaré = le défaut. Voir §3.2c. |
 
 ---
 
@@ -7134,6 +7135,49 @@ mécanisme) ; la description en choisit un et la couche thème (D63)
 le personnalise — les couleurs, les fontes, le logo, la marque. Le
 chantier du thème est ouvert : la forme de la déclaration, le
 contenu d'un style et son extension restent à arbitrer.
+
+**Le multi-thèmes — le dossier themes/, le choix au profil, les
+droits (D753 — amende ma proposition de theme.yml unique).** **« Une
+application peut proposer plusieurs thèmes et les utilisateurs
+peuvent choisir via leur profil le thème de leur choix. Les thèmes
+sont stockés dans un dossier `themes/` avec une déclaration des
+thèmes dans la définition de la version. Un thème est donc un objet
+comme les autres, avec les droits. »** — les quatre arbitrages :
+
+- **le pluriel** : l'application propose plusieurs thèmes —
+  jamais un thème unique imposé ;
+- **le choix au profil** : l'utilisateur choisit son thème comme sa
+  langue (D217–D225) — l'entité user gagne le champ (la lecture
+  notée : `theme: reference`, aux côtés de `language:`) ;
+- **la maison** : le dossier **`themes/`** à la racine de la
+  version, **la déclaration explicite dans la définition de la
+  version** (le patron D415/D644 — ce qui existe se déclare) ;
+- **un objet comme les autres, avec les droits** : le thème porte la
+  confidentialité (D25/D26 — un thème réservé à un groupe se
+  resserre comme le reste) ; le choix du profil n'offre que les
+  thèmes visibles.
+
+*(L'écriture en proposition :*
+
+```yaml
+# themes.yml — la déclaration explicite (le patron D415/D644)
+themes: [classic, dark, durand]
+
+# themes/durand.yml — un thème (la marque du client)
+name: durand
+style: classic                    # le style du socle en assise (D752)
+brand:
+  name: "Durand & Fils"           # la société (D191)
+  logo: resources/logo.svg        # les assets dans resources/ (D346)
+colors:
+  primary: "#1F4E79"
+  accent:  orange
+fonts:
+  default: { font: Inter, size: 14 }
+confidentiality: protected        # les droits — un objet comme les autres
+```
+
+*— le premier thème déclaré = le défaut, l'esprit D437.)*
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -15310,6 +15354,12 @@ avant la synthèse Q16).
   — jamais un chapitre) ; l'arbitrage : Syncytium propose un ou
   plusieurs styles, au même titre que les composants. Le chantier du
   thème est ouvert (la déclaration, le contenu, l'extension).
+- **2026-08-18 (suite 3)** — **Le multi-thèmes (D753)** : le dossier
+  themes/ + la déclaration explicite à la version, le choix au
+  profil (comme la langue), le thème = un objet aux droits ;
+  l'écriture en proposition (themes.yml, style: en assise, brand:,
+  colors:, fonts:, confidentiality:). administration.md mis au
+  niveau (l'entité user gagne theme:).
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -878,6 +878,7 @@ Q58) :
 | D749 | **La délégation détaillée** (précise D715) : le même degré (jamais d'élévation), le don jamais la prise (le délégant ou l'administrateur), l'exception administrateur (s'octroyer les droits de quiconque) — la traçabilité toujours. | Voir §3.2c. |
 | D750 | **logs.yml harmonisé** (corrige D737) : le nom de D342 prime — `logs.yml` partout. | Voir §3.2c. |
 | D751 | **La santé et le backup au menu** (huit entrées) ; **la restauration = une commande interne** (le geste vit hors de l'application). | Voir §3.2c. |
+| D752 | **Le catalogue de styles** (ouvre le chantier du thème) : « au même titre que les composants graphiques, Syncytium propose un ou plusieurs styles » — les styles embarqués du socle (D408), le choix + la personnalisation par la couche thème (D63 : les couleurs, les fontes, le logo, la marque) ; la vérification : le registre ne portait que des touches éparses (D63/D191/D346/D443/D536). | La forme de la déclaration à arbitrer. Voir §3.2c. |
 
 ---
 
@@ -7116,6 +7117,23 @@ la télémétrie, **la santé**, **le backup**) ; **la restauration
 n'est pas un écran** : une commande interne (la famille
 d'encrypt/decrypt/rotate — l'application restaurée est peut-être
 morte, le geste vit hors d'elle).
+
+**Le catalogue de styles (D752 — ouvre le chantier du thème).** La
+vérification demandée (« as-tu notifié ces points ? ») : **le
+registre ne porte que des touches éparses** — la couche thème (D63 :
+les couleurs, les polices, les styles personnalisables — « la couche
+de marque »), le logo à l'accueil (D191/D193), `resources/` (D346 —
+les logos, les icônes, les images partagés entre versions), le
+`style:` au nœud (D443/D536) avec « le style global de
+l'application » et « le thème d'instance » invoqués comme défauts
+**sans jamais être décrits**. L'arbitrage nouveau : **« au même
+titre que les composants graphiques, Syncytium propose un ou
+plusieurs styles. »** — le socle fournit **un catalogue de styles**
+(le patron D408 : les styles embarqués sont les premiers clients du
+mécanisme) ; la description en choisit un et la couche thème (D63)
+le personnalise — les couleurs, les fontes, le logo, la marque. Le
+chantier du thème est ouvert : la forme de la déclaration, le
+contenu d'un style et son extension restent à arbitrer.
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -15287,6 +15305,11 @@ avant la synthèse Q16).
   publication develop→main** (168 commits — les domaines 1–4, Q60,
   la passe de complétude jusqu'à D751). main est au niveau de
   develop.
+- **2026-08-18 (suite 2)** — **Le catalogue de styles (D752)** : la
+  vérification du thème (les touches éparses D63/D191/D346/D443/D536
+  — jamais un chapitre) ; l'arbitrage : Syncytium propose un ou
+  plusieurs styles, au même titre que les composants. Le chantier du
+  thème est ouvert (la déclaration, le contenu, l'extension).
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -15283,6 +15283,10 @@ avant la synthèse Q16).
   « la passe de complétude soldée (D734–D751) », 14 commits sur
   develop. **La deuxième publication develop→main demandée** (la
   première : la PR #27).
+- **2026-08-18** — **La PR #35 fusionnée (vérifiée) : la deuxième
+  publication develop→main** (168 commits — les domaines 1–4, Q60,
+  la passe de complétude jusqu'à D751). main est au niveau de
+  develop.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -880,6 +880,8 @@ Q58) :
 | D751 | **La santé et le backup au menu** (huit entrées) ; **la restauration = une commande interne** (le geste vit hors de l'application). | Voir §3.2c. |
 | D752 | **Le catalogue de styles** (ouvre le chantier du thème) : « au même titre que les composants graphiques, Syncytium propose un ou plusieurs styles » — les styles embarqués du socle (D408), le choix + la personnalisation par la couche thème (D63 : les couleurs, les fontes, le logo, la marque) ; la vérification : le registre ne portait que des touches éparses (D63/D191/D346/D443/D536). | La forme de la déclaration à arbitrer. Voir §3.2c. |
 | D753 | **Le multi-thèmes** (amende la proposition) : plusieurs thèmes par application, **le choix au profil de l'utilisateur** (comme la langue) ; le dossier `themes/` + la déclaration explicite dans la définition de la version (D415/D644) ; **le thème = un objet comme les autres, avec les droits** (la confidentialité — le choix n'offre que le visible). | themes.yml et l'écriture du thème en proposition ; le premier déclaré = le défaut. Voir §3.2c. |
+| D754 | **Le contenu d'un style** (l'écriture D753 validée) : le cadre technique porté par le langage de Syncytium (comme les hooks de code) ; le Web = la représentation HTML des types (le hook d'affichage) complétée par un CSS3 (le style) — le découpage net par type ; le thème surcharge l'implémentation. | Voir §3.2c. |
+| D755 | **Le hook de style — le thème est une combinaison de styles** : la sixième famille de hooks (le comportement des autres, le repli D68), il reprend une partie du style et complète l'affichage aux côtés du hook d'affichage ; la structure des styles ne se généralise pas forcément (pas de schéma unique). | Voir §3.2c. |
 
 ---
 
@@ -7178,6 +7180,50 @@ confidentiality: protected        # les droits — un objet comme les autres
 ```
 
 *— le premier thème déclaré = le défaut, l'esprit D437.)*
+
+**Le contenu d'un style — le cadre technique, HTML/CSS3 (D754 —
+l'écriture de D753 validée, le point 2 arbitré).** **« Le contenu
+d'un style va décrire du cadre technique sélectionné. Comme pour les
+hooks de code, j'envisage qu'un style soit porté par le langage de
+Syncytium. Pour une représentation Web, un CSS3 viendrait compléter
+la définition des types en HTML. Un thème viendrait surcharger cette
+implémentation. Pour un type, nous découperions la représentation
+HTML et son affichage via le CSS3. »** — l'architecture du rendu se
+précise :
+
+- **le style décrit le cadre technique** — porté par **le langage de
+  Syncytium** (comme les hooks de code — le langage et la sandbox du
+  domaine 7, D570) ;
+- **la séparation structure/présentation** : pour le Web, **la
+  représentation HTML des types** (le hook d'affichage — D566.7)
+  est complétée par **un CSS3** (le style) — pour un type, le
+  découpage est net : la représentation HTML d'un côté, son
+  affichage CSS3 de l'autre ;
+- **le thème surcharge cette implémentation** (D753 — la
+  personnalisation par-dessus le style).
+
+**Le hook de style — le thème est une combinaison de styles (D755 —
+le point 3 arbitré).** **« Un hook de thème se comporte comme un
+hook déjà apporté mais en reprenant une partie du style. Un thème
+est donc une combinaison de styles. Nous pourrions définir un
+fichier de configuration de style comportant les éléments clés…
+mais la structure des styles ne peut pas forcément se généraliser.
+Le hook de style (en complément du hook d'affichage) vient compléter
+l'affichage. »** — les arbitrages :
+
+- **la sixième famille de hooks : le hook de style** — il se
+  comporte comme les autres (D52/D408 : le catalogue, la première
+  classe, le repli D68) et **reprend une partie du style** ;
+- **un thème = une combinaison de styles** — le fichier de thème
+  (D753) assemble et surcharge des styles, il n'en invente pas la
+  mécanique ;
+- **la prudence consignée** : un fichier de configuration de style
+  aux éléments clés est envisagé, **mais la structure des styles ne
+  se généralise pas forcément** — pas de schéma unique imposé à
+  tous les styles ;
+- **la complémentarité** : le hook de style complète l'affichage,
+  **aux côtés du hook d'affichage** (le composant rend la structure,
+  le style rend la présentation).
 
 **describe partout — la documentation technique dynamique (D645 —
 généralise D630).** **« Dans le principe de l'auto-documentation,
@@ -15360,6 +15406,12 @@ avant la synthèse Q16).
   l'écriture en proposition (themes.yml, style: en assise, brand:,
   colors:, fonts:, confidentiality:). administration.md mis au
   niveau (l'entité user gagne theme:).
+- **2026-08-18 (suite 4)** — **Le style et son hook (D754–D755)** :
+  l'écriture de D753 validée ; le style = le cadre technique porté
+  par le langage (HTML des types + CSS3, le découpage net, le thème
+  surcharge) ; le hook de style = la sixième famille (le thème = une
+  combinaison de styles, la structure non généralisable, le
+  complément du hook d'affichage). hooks.md mis au niveau.
 - **2026-08-14 (suite 75)** — **`paragraph` et `template` validées**
   (« je valide paragraph et template ») — **LA PASSE DES SURFACES EST
   SOLDÉE** : les sept fiches (list, form, summary, widget, wizard,

--- a/docs/glossaire.md
+++ b/docs/glossaire.md
@@ -231,6 +231,15 @@ Dans Syncytium, la navigation entre le parent et l'enfant est conservée et perm
 description : logos, icônes, fonds — partagés par toutes les versions. Une ressource peut être également un fichier binaire, word, excel, ... En fait, cela représente tout fichier complémentaire utile au bon fonctionnement du projet (Ex : cas de fichiers modèles pour PDF, Word, Excel, ...)
 *(D346)*
 
+**Style** — Le cadre technique du rendu, fourni par Syncytium (« au
+même titre que les composants graphiques, Syncytium propose un ou
+plusieurs styles ») ou apporté par un hook de style — la sixième
+famille. Porté par le langage de Syncytium ; pour le Web, la
+représentation HTML des types (le hook d'affichage) est complétée
+par un CSS3 — la structure d'un côté, la présentation de l'autre.
+La structure des styles ne se généralise pas forcément.
+*(D752, D754–D755)*
+
 **Surface** ou Facette d'une entité ou composant graphique élaboré pour une entité — Un écran généré et nommé : la liste, le formulaire, le
 widget de résumé, le widget de synthèse. *(Q48)*
 
@@ -242,6 +251,15 @@ métier : une à plusieurs personnes le portent. Le technicien est celui qui por
 **Tri** (`sort`) — L'ordre naturel d'un type — alphabétique, numérique,
 chronologique — réglable là où plusieurs ordres se défendent.
 *Ex. : `sort: natural` — item2 avant item10.* *(D125/D380)*
+
+**Thème** (`themes/`, `themes.yml`) — Une combinaison de styles,
+assemblée et surchargée : la marque (la société, le logo —
+`resources/`), les couleurs, les fontes. L'application en propose
+plusieurs ; **l'utilisateur choisit le sien via son profil** (comme
+sa langue) ; le thème est **un objet comme les autres, avec les
+droits** (la confidentialité — le choix n'offre que le visible). Le
+premier déclaré est le défaut.
+*Ex. : `themes: [classic, dark, durand]`.* *(D63, D752–D755)*
 
 **Type** (`type`) — Le contrat d'un champ : ce qu'il accepte, comment
 il se stocke, s'affiche et se cherche. Le nom suffit — un type du

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -50,7 +50,8 @@ versions/<statut>/<version>/
 │   ├── components/
 │   ├── operations/
 │   ├── functions/
-│   └── connectors/
+│   ├── connectors/
+│   └── styles/                # la sixième famille (D755)
 └── <modules>/
 ```
 
@@ -330,6 +331,27 @@ connectors:
     parameters: { path: /exchange/in, format: csv }
     every: 5min                    # le guetteur — détecté, relu (D604)
 ```
+
+### 6. Le hook de style (D752–D755)
+
+Ajoute **un style** au catalogue — « au même titre que les
+composants graphiques, Syncytium propose un ou plusieurs styles »
+(D752) : le socle fournit les siens, le hook en apporte d'autres
+(le comportement des hooks — D52/D408, le repli D68).
+
+**Le contrat (D754–D755)** : le style décrit **le cadre technique**,
+porté par le langage de Syncytium (comme les hooks de code — D570) ;
+pour le Web, **la représentation HTML des types (le hook
+d'affichage — D566.7) est complétée par un CSS3 (le style)** — le
+découpage net par type : la structure d'un côté, la présentation de
+l'autre. **Le hook de style complète l'affichage aux côtés du hook
+d'affichage** ; la structure des styles **ne se généralise pas
+forcément** — pas de schéma unique imposé.
+
+**Le thème n'est pas un hook** : c'est **une combinaison de styles**
+(D755) — déclaré dans `themes/` (D753), il assemble et surcharge ;
+l'utilisateur le choisit à son profil, les droits s'y appliquent
+(un objet comme les autres).
 
 ### Les autres points d'extension consignés
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -19,7 +19,8 @@ mécanisme unique d'extension de Syncytium. Il prépare la documentation
   premier client du mécanisme ;
 - **Le mot « hook » n'apparaît jamais dans la configuration**
   (D408) : un hook ajoute **un nom** au catalogue concerné (un type,
-  un composant, une opération, une fonction, un connecteur) — et ce
+  un composant, une opération, une fonction, un connecteur, un
+  style — D755) — et ce
   nom s'emploie comme un nom du socle ; le doublon de nom = une
   erreur d'ingestion (D344/D396) ;
 - **La première classe** (D65/D68) : un élément ajouté a les mêmes

--- a/docs/rights.md
+++ b/docs/rights.md
@@ -46,7 +46,8 @@ fields:
 
 La confidentialité irrigue tout : les menus filtrés (D193), l'export
 aux colonnes visibles (D196), les widgets hérités surchargeables
-(Q53), la communication (D393).
+(Q53), la communication (D393) — et jusqu'aux **thèmes** (D753 : un
+objet comme les autres, le choix du profil n'offre que le visible).
 
 ## Les droits d'action (D196, D421–D427)
 


### PR DESCRIPTION
## Le chantier du thème — les styles, les thèmes et leur hook (D752–D755)

Le dernier trou relevé par l'auteur avant les cas d'usage : **le style d'affichage, les couleurs, les logos, la marque** — le registre ne portait que des touches éparses (D63 la couche de marque, D191/D193 le logo, D346 `resources/`, D443/D536 un « style global » invoqué sans être décrit). Le chantier est ouvert et soldé en quatre décisions.

### Le catalogue de styles (D752)

« Au même titre que les composants graphiques, **Syncytium propose un ou plusieurs styles** » — les styles embarqués du socle (le patron D408), la couche thème (D63) les personnalise.

### Le multi-thèmes (D753)

- **Plusieurs thèmes par application** ; **l'utilisateur choisit le sien via son profil** (comme sa langue — l'entité `user` gagne `theme:`) ;
- le dossier **`themes/`** à la racine de la version + **la déclaration explicite** (le patron `modules.yml`/`hooks.yml`) ; le premier déclaré = le défaut ;
- **le thème est un objet comme les autres, avec les droits** : la confidentialité s'y applique — le choix du profil n'offre que les thèmes visibles.

### Le contenu d'un style (D754)

Le style décrit **le cadre technique**, porté par le langage de Syncytium (comme les hooks de code) ; pour le Web, **la séparation structure/présentation** : la représentation **HTML** des types (le hook d'affichage — D566.7) complétée par un **CSS3** (le style) — le découpage net par type ; **le thème surcharge cette implémentation**.

### Le hook de style — la sixième famille (D755)

Il se comporte comme les autres hooks (le catalogue, la première classe, le repli D68) et **complète l'affichage aux côtés du hook d'affichage** — le composant rend la structure, le style rend la présentation. Les gardes : **un thème est une combinaison de styles** (il assemble, il n'invente pas la mécanique) ; **la structure des styles ne se généralise pas forcément** — pas de schéma unique imposé.

### Les documents

`hooks.md` (la section 6, l'arborescence `styles/`, la doctrine à six catalogues), `glossaire.md` (les entrées **Style** et **Thème**), `composants.md` (le `style:` D536 raccordé au thème choisi), `rights.md` (le thème aux droits), `administration.md` (l'entité user) — le tour vérifié par grep à la demande de l'auteur.

### L'état

**755 décisions.** La passe de complétude close, le thème couvert — **les cas d'usage (Q59) peuvent s'ouvrir.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
