### PR TITLE
Cas 0 - le hello world : l enquete de satisfaction (D856)

### DIFF
--- a/docs/conception.md
+++ b/docs/conception.md
@@ -17424,6 +17424,10 @@ avant la synthèse Q16).
   cas ; les trois maisons reprises (l'enquête — le généré qui
   suffit ; le véhicule — les cinq morceaux en résumé ; la banque —
   trente-quatre ans repris).
+- **2026-08-31 (suite 2) — LE CAS 0 VALIDÉ.** L'échelle tient ses
+  sept maisons — le degré zéro livré en une séance (D856, seize
+  fichiers, zéro surface). La PR de consolidation préparée
+  (feature/meta-schema → develop, ~5 commits depuis la #39).
 - **2026-08-19 (suite 5 — pause)** — La séance s'arrête sur le
   modèle du cas 1 arrêté (D756–D773 : les cinq cas, la maison
   usecases/, le dépôt examples/01_domestic/ aux huit fichiers, dix

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -982,6 +982,7 @@ Q58) :
 | D853 | **La durée du contrat et la finalisation d'après-migration** (solde la note de D852) : **`duree_contrat`** — la saisie du paramétrage (l'intention contractuelle, le générateur l'engendre), distincte de `duree_echeances` (le calculé — le réel compté) ; **`finaliser_vehicule`** — l'opération exécutée **après la migration** (`when: migrated` — l'issue de `migrate`, le patron `generated` D796 généralisé) : elle complète ce que la reprise ne porte pas (les repris gagnent leur `duree_contrat` du compte des échéances), idempotente — elle ne complète que l'absent ; en général, l'occasion d'« engendrer des lignes ou faire des compléments après la migration ». | Voir §3.2c. |
 | D854 | **La troncature naturelle du temps** (clôt R7 — le dernier manque du morceau 5) : l'affectation vers un `date` de nature plus grossière **tronque à sa nature** (`premier_mois: date` versé dans un `date[yyyy-mm]` → le mois) — le type-cible fait autorité (la cohérence du `mask` qui pilote la lecture, D820) ; **la formule explicite reste utilisable** au mapping, au choix de l'écrivain. | Voir §3.2c. |
 | D855 | **Le morceau 5 validé — le cas véhicule clos** (solde D826) : les cinq morceaux du second projet domestique livrés — la racine et l'environnement (11 fichiers), le modèle (le module transport aux 5 entités), les opérations (4 hooks), les surfaces (les six onglets, l'écran d'accueil) et la reprise (8 sources, 10 phases sur les classeurs réels 1992-2026) ; 26 décisions du cas (D830–D855) ; usecases/01_vehicule.md = le récit complet, examples/01_vehicule/ = l'application entière. | La PR de consolidation préparée. Voir §3.2c. |
+| D856 | **Le cas 0 — le « hello world »** (amende l'échelle D756/D827 : sept maisons) : l'enquête de satisfaction — **un module (`satisfaction`), une table (`enquete`) et une composition (`reponse`), sans migration, le gui entièrement généré** (les défauts D64/D438/D486 — la promesse fondatrice montrée nue) ; l'usage : « récolter rapidement des informations » ; deux calculés vivants (`reponses.count()`, `reponses.avg(note)`) ; la maison `usecases/00_enquete.md` + `examples/00_enquete/` — dix-huit fichiers, zéro surface (le module `satisfaction` : l'éponymie triple évitée, la leçon D831). | Voir §3.2c. |
 
 ---
 
@@ -17409,6 +17410,14 @@ avant la synthèse Q16).
   cas véhicule entier (D830–D855, 53 commits — la fusion par
   l'auteur, l'ancêtre vérifié : develop contient la branche
   entière). La publication develop → main (la 4e) sur demande.
+- **2026-08-31 — LE CAS 0 OUVERT ET LIVRÉ (D856).** Le « hello
+  world » de l'auteur : l'enquête de satisfaction — un module
+  (satisfaction), une table (enquete) et une composition
+  (reponse), sans migration, le gui entièrement généré ; l'usage :
+  récolter rapidement des informations. Le cas tient en un
+  morceau — dix-huit fichiers, zéro surface, deux calculés
+  vivants ; l'échelle gagne son degré zéro (sept maisons). **En
+  validation.**
 - **2026-08-19 (suite 5 — pause)** — La séance s'arrête sur le
   modèle du cas 1 arrêté (D756–D773 : les cinq cas, la maison
   usecases/, le dépôt examples/01_domestic/ aux huit fichiers, dix

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -17405,6 +17405,10 @@ avant la synthèse Q16).
   consolidation feature/meta-schema → develop préparée (~55
   commits depuis la #38). **La suite : les cas 3–6 de l'échelle
   (D756), ou la documentation (Q58) — au choix de l'auteur.**
+- **2026-08-30 (fusion) — LA PR #39 FUSIONNÉE.** develop porte le
+  cas véhicule entier (D830–D855, 53 commits — la fusion par
+  l'auteur, l'ancêtre vérifié : develop contient la branche
+  entière). La publication develop → main (la 4e) sur demande.
 - **2026-08-19 (suite 5 — pause)** — La séance s'arrête sur le
   modèle du cas 1 arrêté (D756–D773 : les cinq cas, la maison
   usecases/, le dépôt examples/01_domestic/ aux huit fichiers, dix

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -17418,6 +17418,12 @@ avant la synthèse Q16).
   morceau — seize fichiers, zéro surface, deux calculés
   vivants ; l'échelle gagne son degré zéro (sept maisons). **En
   validation.**
+- **2026-08-31 (suite)** — **La configuration du cas 0 validée ;
+  les release-notes personnalisés.** La remarque de l'auteur :
+  le squelette copié s'interdit — chaque version.yml raconte son
+  cas ; les trois maisons reprises (l'enquête — le généré qui
+  suffit ; le véhicule — les cinq morceaux en résumé ; la banque —
+  trente-quatre ans repris).
 - **2026-08-19 (suite 5 — pause)** — La séance s'arrête sur le
   modèle du cas 1 arrêté (D756–D773 : les cinq cas, la maison
   usecases/, le dépôt examples/01_domestic/ aux huit fichiers, dix

--- a/docs/conception.md
+++ b/docs/conception.md
@@ -982,7 +982,7 @@ Q58) :
 | D853 | **La durée du contrat et la finalisation d'après-migration** (solde la note de D852) : **`duree_contrat`** — la saisie du paramétrage (l'intention contractuelle, le générateur l'engendre), distincte de `duree_echeances` (le calculé — le réel compté) ; **`finaliser_vehicule`** — l'opération exécutée **après la migration** (`when: migrated` — l'issue de `migrate`, le patron `generated` D796 généralisé) : elle complète ce que la reprise ne porte pas (les repris gagnent leur `duree_contrat` du compte des échéances), idempotente — elle ne complète que l'absent ; en général, l'occasion d'« engendrer des lignes ou faire des compléments après la migration ». | Voir §3.2c. |
 | D854 | **La troncature naturelle du temps** (clôt R7 — le dernier manque du morceau 5) : l'affectation vers un `date` de nature plus grossière **tronque à sa nature** (`premier_mois: date` versé dans un `date[yyyy-mm]` → le mois) — le type-cible fait autorité (la cohérence du `mask` qui pilote la lecture, D820) ; **la formule explicite reste utilisable** au mapping, au choix de l'écrivain. | Voir §3.2c. |
 | D855 | **Le morceau 5 validé — le cas véhicule clos** (solde D826) : les cinq morceaux du second projet domestique livrés — la racine et l'environnement (11 fichiers), le modèle (le module transport aux 5 entités), les opérations (4 hooks), les surfaces (les six onglets, l'écran d'accueil) et la reprise (8 sources, 10 phases sur les classeurs réels 1992-2026) ; 26 décisions du cas (D830–D855) ; usecases/01_vehicule.md = le récit complet, examples/01_vehicule/ = l'application entière. | La PR de consolidation préparée. Voir §3.2c. |
-| D856 | **Le cas 0 — le « hello world »** (amende l'échelle D756/D827 : sept maisons) : l'enquête de satisfaction — **un module (`satisfaction`), une table (`enquete`) et une composition (`reponse`), sans migration, le gui entièrement généré** (les défauts D64/D438/D486 — la promesse fondatrice montrée nue) ; l'usage : « récolter rapidement des informations » ; deux calculés vivants (`reponses.count()`, `reponses.avg(note)`) ; la maison `usecases/00_enquete.md` + `examples/00_enquete/` — dix-huit fichiers, zéro surface (le module `satisfaction` : l'éponymie triple évitée, la leçon D831). | Voir §3.2c. |
+| D856 | **Le cas 0 — le « hello world »** (amende l'échelle D756/D827 : sept maisons) : l'enquête de satisfaction — **un module (`satisfaction`), une table (`enquete`) et une composition (`reponse`), sans migration, le gui entièrement généré** (les défauts D64/D438/D486 — la promesse fondatrice montrée nue) ; l'usage : « récolter rapidement des informations » ; deux calculés vivants (`reponses.count()`, `reponses.avg(note)`) ; la maison `usecases/00_enquete.md` + `examples/00_enquete/` — seize fichiers, zéro surface (le module `satisfaction` : l'éponymie triple évitée, la leçon D831). | Voir §3.2c. |
 
 ---
 
@@ -17415,7 +17415,7 @@ avant la synthèse Q16).
   (satisfaction), une table (enquete) et une composition
   (reponse), sans migration, le gui entièrement généré ; l'usage :
   récolter rapidement des informations. Le cas tient en un
-  morceau — dix-huit fichiers, zéro surface, deux calculés
+  morceau — seize fichiers, zéro surface, deux calculés
   vivants ; l'échelle gagne son degré zéro (sept maisons). **En
   validation.**
 - **2026-08-19 (suite 5 — pause)** — La séance s'arrête sur le

--- a/examples/00_enquete/environments/environments.yml
+++ b/examples/00_enquete/environments/environments.yml
@@ -1,0 +1,4 @@
+# Déclaration des environnements d'exécution
+# Un seul environnement : le poste du foyer (le patron du domestique — D799)
+
+home: home/home.yml

--- a/examples/00_enquete/environments/home/connectors.yml
+++ b/examples/00_enquete/environments/home/connectors.yml
@@ -1,0 +1,12 @@
+# le natif du domestique (D729)
+database:
+  type: storage
+  class: sqlite
+
+# « pas de secrets dans la famille » (D759)
+authentication:
+  class: none
+
+# le mail muet, assumé (D763)
+smtp:
+  class: none

--- a/examples/00_enquete/environments/home/documentation.yml
+++ b/examples/00_enquete/environments/home/documentation.yml
@@ -1,0 +1,2 @@
+# La génération de la documentation du projet
+# À décrire et compléter (le domaine 6 — Q58)

--- a/examples/00_enquete/environments/home/home.yml
+++ b/examples/00_enquete/environments/home/home.yml
@@ -1,0 +1,18 @@
+name: home
+description: Environnement d'exécution du poste du foyer
+
+# Configuration de la journalisation
+
+logging: logging.yml
+
+# Configuration de la génération de la documentation
+
+documentation: documentation.yml
+
+# Configuration des connecteurs de l'application
+
+connectors: connectors.yml
+
+# Configuration générale transcendant les versions et propre à un environnement d'exécution
+
+settings: settings.yml

--- a/examples/00_enquete/environments/home/logging.yml
+++ b/examples/00_enquete/environments/home/logging.yml
@@ -1,0 +1,7 @@
+# La journalisation — le contrat consigné (D737/D743/D750/D800, le nom D830)
+
+log:
+  # verbose | debug | info | warning | error | exception
+  level: info
+  output: file:${SYNCYTIUM_LOG_DIRECTORY}
+  retention: 90d

--- a/examples/00_enquete/environments/home/settings.yml
+++ b/examples/00_enquete/environments/home/settings.yml
@@ -1,0 +1,3 @@
+# Les éléments de configuration non versionnés de l'application
+# Pour le moment, il est vide.
+# Le relais mail des notifications (D836) reste au défaut : aucun envoi.

--- a/examples/00_enquete/syncytium.yml
+++ b/examples/00_enquete/syncytium.yml
@@ -1,0 +1,15 @@
+# Le cas 0 — le « hello world ! » : l'enquête de satisfaction (D856)
+# L'entrée du projet (D767) : la déclaration fait foi, rien ne se déduit de l'arborescence.
+
+# Identification et description du projet
+
+name: enquete
+description: L'enquête de satisfaction — récolter rapidement des informations
+
+# Liste des environnements d'exécution
+
+environments: environments/environments.yml
+
+# Liste des versions de l'application
+
+versions: versions/versions.yml

--- a/examples/00_enquete/versions/beta/beta.yml
+++ b/examples/00_enquete/versions/beta/beta.yml
@@ -1,0 +1,8 @@
+# Les versions éligibles au mode beta
+
+# pas de déclaration orpheline (D805)
+environment: home
+
+# Le pattern regex des versions (D806)
+versions:
+  - v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/version\.yml

--- a/examples/00_enquete/versions/beta/v1.0.0.0/satisfaction/enquete/enquete.yml
+++ b/examples/00_enquete/versions/beta/v1.0.0.0/satisfaction/enquete/enquete.yml
@@ -1,0 +1,10 @@
+# L'enquête — la campagne et ses réponses. AUCUNE surface déclarée :
+# le gui est entièrement généré (la promesse fondatrice — D64, les
+# défauts D438/D486), les labels et hints font parler le généré.
+name: enquete
+description: Une enquête de satisfaction — la campagne et ses réponses
+label: "{titre}"
+identity: [titre]
+
+# La liste des champs de l'entité
+fields: fields.yml

--- a/examples/00_enquete/versions/beta/v1.0.0.0/satisfaction/enquete/fields.yml
+++ b/examples/00_enquete/versions/beta/v1.0.0.0/satisfaction/enquete/fields.yml
@@ -1,0 +1,39 @@
+titre:
+  type: text[..60]
+  required: true
+  label:
+    fr: Titre
+  placeholder:
+    fr: Satisfaction du repas de fête
+  hint:
+    fr: Le nom de la campagne — il identifie l'enquête.
+
+date:
+  type: date
+  label:
+    fr: Date
+  hint:
+    fr: Le jour de la collecte — optionnel.
+
+# --- la composition (D399) — le grain d'écriture ---
+
+reponses:
+  type: list of reponse
+  label:
+    fr: Réponses
+
+# ------ Champs calculés ------
+
+nb_reponses:
+  type: integer
+  formula: reponses.count()
+  label:
+    fr: Nombre de réponses
+
+note_moyenne:
+  type: decimal
+  formula: reponses.avg(note)
+  label:
+    fr: Note moyenne
+  hint:
+    fr: La moyenne des notes — elle se recalcule à chaque réponse.

--- a/examples/00_enquete/versions/beta/v1.0.0.0/satisfaction/reponse/fields.yml
+++ b/examples/00_enquete/versions/beta/v1.0.0.0/satisfaction/reponse/fields.yml
@@ -1,0 +1,23 @@
+repondant:
+  type: text[..40]
+  required: true
+  label:
+    fr: Répondant
+  placeholder:
+    fr: Marie
+
+note:
+  type: integer[1..5]
+  required: true
+  label:
+    fr: Note
+  hint:
+    fr: De 1 (déçu) à 5 (ravi).
+
+commentaire:
+  # le multi-ligne déduit de la taille (D366)
+  type: text[..200]
+  label:
+    fr: Commentaire
+  placeholder:
+    fr: Le dessert était parfait !

--- a/examples/00_enquete/versions/beta/v1.0.0.0/satisfaction/reponse/reponse.yml
+++ b/examples/00_enquete/versions/beta/v1.0.0.0/satisfaction/reponse/reponse.yml
@@ -1,0 +1,8 @@
+# La réponse — un répondant, une note, un mot. Le formulaire et la
+# liste par défaut suffisent (aucun gui déclaré).
+name: reponse
+description: Une réponse à l'enquête — le répondant, la note, le commentaire
+label: "${name}"
+
+# La liste des champs de l'entité
+fields: fields.yml

--- a/examples/00_enquete/versions/beta/v1.0.0.0/satisfaction/satisfaction.yml
+++ b/examples/00_enquete/versions/beta/v1.0.0.0/satisfaction/satisfaction.yml
@@ -1,0 +1,10 @@
+# Le module déclare ses entités (D765) — les chemins relatifs au
+# fichier courant (D768). « satisfaction » : le nommage libre (D807)
+# évite l'éponymie triple enquete/enquete/enquete.yml (la leçon
+# transport — D831) et donne des références lisibles.
+name: satisfaction
+description: La collecte des enquêtes de satisfaction
+
+entities:
+  - enquete/enquete.yml
+  - reponse/reponse.yml

--- a/examples/00_enquete/versions/beta/v1.0.0.0/version.yml
+++ b/examples/00_enquete/versions/beta/v1.0.0.0/version.yml
@@ -2,11 +2,16 @@
 
 version: 1.0.0.0
 release-notes: >
-  Cette version initialise le projet :
-  # Description de la structure de données
-  ## Une enquête de satisfaction (la campagne)
-  ## Une réponse (le répondant, la note, le commentaire)
-  # Aucune migration, aucune surface déclarée — le gui est généré
+  La première version de l'enquête de satisfaction — le « hello
+  world » de Syncytium : un module, une table et une composition,
+  aucune surface déclarée.
+  # Le modèle
+  ## L'enquête — le titre, la date, les réponses ; le nombre de
+  réponses et la note moyenne se calculent seuls
+  ## La réponse — le répondant, la note de 1 à 5, le commentaire
+  # Le généré
+  ## Les formulaires et les listes naissent des défauts du socle :
+  la collecte peut commencer dès le chargement
 
 # Déclaration des modules
 # Pour l'exemple, nous n'avons qu'un seul module

--- a/examples/00_enquete/versions/beta/v1.0.0.0/version.yml
+++ b/examples/00_enquete/versions/beta/v1.0.0.0/version.yml
@@ -1,0 +1,15 @@
+# Identification et description de la version — la version en tête (D801)
+
+version: 1.0.0.0
+release-notes: >
+  Cette version initialise le projet :
+  # Description de la structure de données
+  ## Une enquête de satisfaction (la campagne)
+  ## Une réponse (le répondant, la note, le commentaire)
+  # Aucune migration, aucune surface déclarée — le gui est généré
+
+# Déclaration des modules
+# Pour l'exemple, nous n'avons qu'un seul module
+
+modules:
+  - satisfaction/satisfaction.yml

--- a/examples/00_enquete/versions/production/production.yml
+++ b/examples/00_enquete/versions/production/production.yml
@@ -1,0 +1,7 @@
+# Les versions éligibles au mode production
+
+# pas de déclaration orpheline (D805)
+environment: home
+
+versions:
+  - v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/version\.yml

--- a/examples/00_enquete/versions/versions.yml
+++ b/examples/00_enquete/versions/versions.yml
@@ -1,0 +1,5 @@
+# Les statuts des versions — déclarés à l'usage (D804)
+
+beta: beta/beta.yml
+
+production: production/production.yml

--- a/examples/01_vehicule/versions/beta/v1.0.0.0/version.yml
+++ b/examples/01_vehicule/versions/beta/v1.0.0.0/version.yml
@@ -2,14 +2,24 @@
 
 version: 1.0.0.0
 release-notes: >
-  Cette version initialise le projet :
-  # Description de la structure de données
-  ## Un véhicule (thermique ou électrique)
-  ## Une consommation (plein ou charge)
-  ## Une ligne d'entretien (le journal de vie)
-  ## Le financement (crédit ou LOA)
-  ## L'échéancier des révisions
-  # Description de la reprise des classeurs historiques
+  La première version de la maintenance des véhicules du foyer —
+  du classeur Excel à l'application.
+  # Le modèle
+  ## Le véhicule — l'identification (la plaque), le financement à
+  plat (comptant, crédit, LOA), le cycle Création → Actif →
+  Clôture, le bilan tout calculé (0,249 €/km)
+  ## La consommation (les pleins et les charges au rang), le
+  journal de vie, les règles de révision, l'échéancier
+  # Les opérations
+  ## creer_echeancier à la validation du financement,
+  ajuster_echeancier au bouton, clore_echeancier à la vente,
+  finaliser_vehicule après la migration
+  # Les surfaces
+  ## L'accueil — les révisions échues puis les véhicules en
+  cartes ; le formulaire aux six onglets, l'édition en ligne
+  # La reprise
+  ## Les dix classeurs 1992-2026 — huit sources, dix phases, la
+  jointure par la plaque
 
 # Déclaration des hooks
 

--- a/examples/02_banque/versions/beta/v1.0.0.0/version.yml
+++ b/examples/02_banque/versions/beta/v1.0.0.0/version.yml
@@ -2,13 +2,21 @@
 
 version: 1.0.0.0
 release-notes: >
-  Cette version initialise le projet :
-  # Description de la structure de données
-  ## Un compte bancaire
-  ## Une écriture
-  ## Les lieux
-  ## Les budgets
-  # Description de la récupération de données historiques
+  La première version de la gestion des comptes bancaires du
+  foyer — trente-quatre ans d'écritures repris.
+  # Le modèle
+  ## Le compte et ses écritures — la devise dans la valeur (euro
+  et franc), le solde continu, les calculés débit/crédit
+  ## Les référentiels des budgets et des lieux — la création
+  directe au picker
+  # Les opérations
+  ## dupliquer (entre deux dates), propager (les similaires),
+  virer (les deux écritures liées), creer_releve (le PDF pose la
+  date d'impression)
+  # La reprise
+  ## L'historique 1992-2026 (~23 400 écritures) — trois phases,
+  les comptes aux marqueurs, le rapprochement des virements par
+  le cache
 
 # Déclaration des ressources
 

--- a/usecases/00_enquete.md
+++ b/usecases/00_enquete.md
@@ -1,0 +1,51 @@
+# Le cas 0 — le « hello world ! » : l'enquête de satisfaction
+
+*Le degré zéro de l'échelle (D756/D827, amendée par D856) — la
+promesse fondatrice montrée nue : un modèle déclaré, une application
+qui naît, **aucune surface écrite**. Le cadre du cas : le contexte,
+le modèle, **la forme** (le dépôt `examples/00_enquete/` écrit pour
+de vrai) et **les manques**. Les décisions citées renvoient à
+[../docs/conception.md](../docs/conception.md).*
+
+## Le contexte (D856)
+
+- **le rôle** : le « hello world » de Syncytium — « un modèle avec un
+  module, 1 table et 1 composition, sans migration et avec gui généré
+  automatiquement » ;
+- **l'usage** : « montrer que cela peut être utile pour récolter
+  rapidement des informations » — l'enquête de satisfaction : la
+  campagne (le titre, la date) et ses réponses (le répondant, la
+  note de 1 à 5, le commentaire) ;
+- **ce que le cas montre** : le formulaire par défaut (D438), la
+  liste par défaut, la composition embarquée par défaut (D486), les
+  calculés qui vivent seuls (`nb_reponses`, `note_moyenne` — D255),
+  et le généré qui parle français (les `label`/`hint`/`placeholder`
+  de l'auto-documentation — D258/D840) ;
+- **ce que le cas n'a pas** : ni hooks, ni opérations déclarées, ni
+  `gui:`, ni reprise — les dossiers n'existent pas.
+
+## Le modèle
+
+- **`satisfaction`** — le module (le nommage libre D807 : l'éponymie
+  triple `enquete/enquete/enquete.yml` évitée — la leçon transport
+  D831) ;
+- **`enquete`** — la campagne : `titre` (l'identité), `date`
+  optionnelle, la composition `reponses`, et deux calculés —
+  `nb_reponses` (`reponses.count()`), `note_moyenne`
+  (`reponses.avg(note)`) ;
+- **`reponse`** — le répondant (`text[..40]`), la `note`
+  (`integer[1..5]` — « De 1 (déçu) à 5 (ravi) »), le `commentaire`
+  (multi-ligne déduit — D366).
+
+## La forme — le dépôt
+
+Un seul morceau — le cas tient entier : l'assise du domestique
+(l'arborescence pleine D799–D810, `logging.yml` D830,
+`authentication: none` D759, `smtp: none` D763) et le module aux
+deux entités. **Dix-huit fichiers en tout, zéro surface.**
+
+## Les manques relevés
+
+*(chaque frottement deviendrait une décision — aucun relevé : les
+défauts du socle couvrent le cas de bout en bout, c'est sa raison
+d'être)*

--- a/usecases/00_enquete.md
+++ b/usecases/00_enquete.md
@@ -42,7 +42,7 @@ de vrai) et **les manques**. Les décisions citées renvoient à
 Un seul morceau — le cas tient entier : l'assise du domestique
 (l'arborescence pleine D799–D810, `logging.yml` D830,
 `authentication: none` D759, `smtp: none` D763) et le module aux
-deux entités. **Dix-huit fichiers en tout, zéro surface.**
+deux entités. **Seize fichiers en tout, zéro surface.**
 
 ## Les manques relevés
 


### PR DESCRIPTION
## Le cas 0 — le « hello world ! » : l'enquête de satisfaction (D856)

Le degré zéro de l'échelle (D756/D827 — sept maisons désormais) : **un module, une table et une composition, sans migration, le gui entièrement généré** — la promesse fondatrice montrée nue. L'usage : récolter rapidement des informations.

### Le modèle (seize fichiers, zéro surface)

- le module **`satisfaction`** (le nommage libre D807 — l'éponymie triple évitée, la leçon `transport`) ;
- **`enquete`** — le titre (l'identité), la date, la composition `reponses`, et deux calculés vivants : `nb_reponses` (`reponses.count()`), `note_moyenne` (`reponses.avg(note)`) ;
- **`reponse`** — le répondant, la note (`integer[1..5]` — « De 1 (déçu) à 5 (ravi) »), le commentaire (multi-ligne déduit) ;
- ni `hooks/`, ni `operations:`, ni `gui:`, ni `reprise/` — les dossiers n'existent pas : les défauts du socle (D64/D438/D486) font tout, l'auto-documentation (`label`/`hint`/`placeholder`) fait parler le généré.

### Aussi dans cette PR

- **les release-notes personnalisés aux trois cas** (la remarque de l'auteur — le squelette copié s'interdit, chaque `version.yml` raconte son cas) ;
- le journal de la fusion #39 et de la validation du cas 0 (le registre à 856 décisions).

### La maison

- `usecases/00_enquete.md` — le récit (le contexte, le modèle, la forme, les manques : aucun) ;
- `examples/00_enquete/` — l'application entière.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
